### PR TITLE
Add ProxySQL LLC copyright notice to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -190,6 +190,7 @@ Copyright 2014 Outbrain Inc
 Copyright 2015 Booking.com
 Copyright 2016 - Feb 2020 GitHub
 Copyright 2020 - Shlomi Noach
+Copyright 2026 ProxySQL LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- Adds `Copyright 2026 ProxySQL LLC` to the LICENSE file after the existing copyright notices (Outbrain, Booking.com, GitHub, Shlomi Noach)
- All existing copyright attributions are preserved unchanged

Closes #2

## Test plan

- [ ] Verify LICENSE file contains all original copyright lines intact
- [ ] Verify new ProxySQL LLC copyright line is present after the Shlomi Noach line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright attribution in the license file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->