### PR TITLE
Rebrand README for ProxySQL LLC maintainership

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,14 @@
-![](https://github.com/openark/orchestrator/workflows/CI/badge.svg)
-![](https://github.com/openark/orchestrator/workflows/upgrade/badge.svg)
-![](https://github.com/openark/orchestrator/workflows/system%20tests/badge.svg)
-[![downloads](https://img.shields.io/github/downloads/openark/orchestrator/total.svg)](https://github.com/openark/orchestrator/releases) [![release](https://img.shields.io/github/release/openark/orchestrator.svg)](https://github.com/openark/orchestrator/releases)
+![](https://github.com/proxysql/orchestrator/workflows/CI/badge.svg)
+![](https://github.com/proxysql/orchestrator/workflows/upgrade/badge.svg)
+![](https://github.com/proxysql/orchestrator/workflows/system%20tests/badge.svg)
+[![downloads](https://img.shields.io/github/downloads/proxysql/orchestrator/total.svg)](https://github.com/proxysql/orchestrator/releases) [![release](https://img.shields.io/github/release/proxysql/orchestrator.svg)](https://github.com/proxysql/orchestrator/releases)
 
-> **NOTE:** This is a fork of the abandoned [Orchestrator](https://github.com/openark/orchestrator) project. Percona is not the public maintainer of the Orchestrator project. We modify this fork almost exclusively for use in our Kubernetes Operators, but we make our changes available to the open-source community if they suit your needs.
+> **Maintained by [ProxySQL LLC](https://proxysql.com).** We are committed to keeping orchestrator alive and moving forward. Contributions from the community are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
 
->We are not currently entertaining external enhancements or feature requests.  We do, however, believe Orchestrator has potential and are open to exploring its future as a community-driven project. We welcome collaboration with interested organizations. Our priority is determining whether sufficient resources (time and funding) can be secured to ensure Orchestrator's continued maintenance and development. We're open to discussing potential partnerships with organizations who might be interested in supporting this effort. 
-
->If you or your organization are willing to contribute resources or funding, please reach out to orchestrator@percona.com.
+# orchestrator [[Documentation]](https://github.com/proxysql/orchestrator/tree/master/docs)
 
 
-# orchestrator [[Documentation]](https://github.com/percona/orchestrator/tree/master/docs)
-
-
-![Orchestrator logo](https://github.com/openark/orchestrator/raw/master/docs/images/orchestrator-logo-wide.png)
+![Orchestrator logo](docs/images/orchestrator-logo-wide.png)
 
 `orchestrator` is a MySQL high availability and replication management tool, runs as a service and provides command line access, HTTP API and Web interface. `orchestrator` supports:
 
@@ -64,14 +59,32 @@ recovery itself.
 - There is also an [orchestrator-mysql](https://groups.google.com/forum/#!forum/orchestrator-mysql) Google groups forum to discuss topics related to orchestrator
 - More...
 
-Read the [Orchestrator documentation](https://github.com/openark/orchestrator/tree/master/docs)
+Read the [Orchestrator documentation](https://github.com/proxysql/orchestrator/tree/master/docs)
+
+#### Future Vision
+
+ProxySQL LLC is investing in orchestrator's long-term future:
+
+- **ProxySQL-native integration** — tighter coupling between orchestrator's topology awareness and ProxySQL's query routing for seamless failover.
+- **PostgreSQL exploration** — investigating replication management capabilities beyond MySQL.
+- **Modernization** — updated dependencies, improved CI/CD, and a path toward a cleaner Go module structure.
+
+#### History
 
 Authored by [Shlomi Noach](https://github.com/shlomi-noach):
 
-- 2020- as https://github.com/openark/orchestrator
-- 2016-2020 at [GitHub](http://github.com) as https://github.com/github/orchestrator
-- 2015 at [Booking.com](http://booking.com) as https://github.com/outbrain/orchestrator
 - 2014 at [Outbrain](http://outbrain.com) as https://github.com/outbrain/orchestrator
+- 2015 at [Booking.com](http://booking.com) as https://github.com/outbrain/orchestrator
+- 2016-2020 at [GitHub](http://github.com) as https://github.com/github/orchestrator
+- 2020-2024 as https://github.com/openark/orchestrator
+- 2024-2025 maintained by [Percona](https://percona.com) as https://github.com/percona/orchestrator
+- 2026-present maintained by [ProxySQL LLC](https://proxysql.com) as https://github.com/proxysql/orchestrator
+
+#### Community
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — how to contribute
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — community standards
+- [SECURITY.md](SECURITY.md) — reporting security vulnerabilities
 
 #### Related projects
 


### PR DESCRIPTION
## Summary

- Replace Percona fork notice with ProxySQL LLC maintainer statement and link to CONTRIBUTING.md
- Update all badge URLs, download/release badge URLs, and documentation links from `openark/orchestrator` and `percona/orchestrator` to `proxysql/orchestrator`
- Use local logo path (`docs/images/orchestrator-logo-wide.png`) instead of external GitHub URL
- Add "Future Vision" section covering ProxySQL-native integration, PostgreSQL exploration, and modernization
- Add "History" section with full lineage: Outbrain (2014) -> Booking.com (2015) -> GitHub (2016) -> openark (2020) -> Percona (2024) -> ProxySQL LLC (2026)
- Add "Community" section linking to CONTRIBUTING.md, CODE_OF_CONDUCT.md, and SECURITY.md
- Remove Percona-specific contact language (`orchestrator@percona.com`)
- All existing feature descriptions (Discovery, Refactoring, Recovery, Interface, Additional perks) preserved

## Test plan

- [ ] Verify all badge URLs point to `proxysql/orchestrator` and render correctly
- [ ] Verify logo renders from local path
- [ ] Verify documentation link points to `proxysql/orchestrator`
- [ ] Confirm no stale `openark` or `percona` references outside the deliberate history section
- [ ] Confirm governance file links will work once Task 3 merges

Closes #1