### PR TITLE
Fix CI: update Go version and GitHub Actions to current versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - name: Set up Go 1.16
-      uses: actions/setup-go@v1
+    - name: Set up Go
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.16
+        go-version: '1.25.7'
 
     - name: Test source code
       run:  script/test-source
@@ -45,7 +45,7 @@ jobs:
       run:  script/test-docs
 
     - name: Upload orchestrator binary artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: orchestrator
         path: bin/orchestrator

--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up Go 1.16
-      uses: actions/setup-go@v1
+    - name: Set up Go
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.16
+        go-version: '1.25.7'
 
     - name: check out
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: build
       run:  script/test-build
@@ -26,7 +26,7 @@ jobs:
     - name: clone orchestrator-ci-env
       run: |
         # Only clone if not already running locally at latest commit
-        remote_commit=$(git ls-remote https://github.com/openark/orchestrator-ci-env.git HEAD | cut -f1)
+        remote_commit=$(git ls-remote https://github.com/percona/orchestrator-ci-env.git HEAD | cut -f1)
         local_commit="unknown"
         [ -d "orchestrator-ci-env" ] && local_commit=$(cd orchestrator-ci-env && git log --format="%H" -n 1)
 
@@ -35,7 +35,7 @@ jobs:
 
         if [ "$remote_commit" != "$local_commit" ] ; then
           rm -rf ./orchestrator-ci-env
-          git clone https://github.com/openark/orchestrator-ci-env.git
+          git clone https://github.com/percona/orchestrator-ci-env.git
         fi
 
     - name: apt-get update

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -11,16 +11,16 @@ jobs:
     #     backend: [sqlite, MySQL]
 
     steps:
-    - name: Set up Go 1.16
-      uses: actions/setup-go@v1
+    - name: Set up Go
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.16
+        go-version: '1.25.7'
 
     - name: Start local MySQL
       run: sudo /etc/init.d/mysql start
 
     - name: check out
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: copy config file template
       run: |
@@ -41,7 +41,7 @@ jobs:
         echo "MySQL config generated"
 
     - name: check out master branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: master
 
@@ -60,7 +60,7 @@ jobs:
 
 
     - name: check out PR branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: build branch
       run:  script/test-build


### PR DESCRIPTION
## Summary

- Update Go version from 1.16 to 1.25.7 across all three workflow files
- Bump `actions/checkout` from v2 to v4
- Bump `actions/setup-go` from v1 to v5
- Bump `actions/upload-artifact` from v1 to v4 (in main.yml)
- Update `orchestrator-ci-env` clone URL from openark to percona (in system.yml)
- Rename step "Set up Go 1.16" to "Set up Go" in all workflows

## Test plan

- [ ] CI workflows trigger and pass on this PR
- [ ] Verify no remaining references to `@v1`, `@v2`, or `go-version: 1.16` in workflow files

Closes #5