### PR TITLE
Add ProxySQL LLC copyright notice to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -190,6 +190,7 @@ Copyright 2014 Outbrain Inc
 Copyright 2015 Booking.com
 Copyright 2016 - Feb 2020 GitHub
 Copyright 2020 - Shlomi Noach
+Copyright 2026 ProxySQL LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Adds `Copyright 2026 ProxySQL LLC` to the LICENSE file's copyright notices section (lines 189-193)
- All existing copyright attributions (Outbrain, Booking.com, GitHub, Shlomi Noach) are preserved

## Test plan
- [ ] Verify LICENSE file retains valid Apache 2.0 text
- [ ] Verify all prior copyright lines are unchanged
- [ ] Verify new ProxySQL LLC line appears after existing entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright attribution in the license file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->