### PR TITLE
Update documentation links from openark/percona to proxysql

### DIFF
--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -1,3 +1,3 @@
 # Bugs
 
-Please report bugs on the [Issues page](https://github.com/openark/orchestrator/issues)
+Please report bugs on the [Issues page](https://github.com/proxysql/orchestrator/issues)

--- a/docs/build.md
+++ b/docs/build.md
@@ -42,7 +42,7 @@ Requirements:
 Run:
 
 ```
-    git clone git@github.com:openark/orchestrator.git
+    git clone git@github.com:proxysql/orchestrator.git
     cd orchestrator
 ```
 

--- a/docs/ci-env.md
+++ b/docs/ci-env.md
@@ -50,7 +50,7 @@ Assuming `orchestrator` is built into `bin/orchestrator` (`./script/build` if no
 $ bin/orchestrator --config=conf/orchestrator-ci-env.conf.json --debug http
 ```
 
-[`conf/orchestrator-ci-env.conf.json`](https://github.com/openark/orchestrator/blob/master/conf/orchestrator-ci-env.conf.json) is designed to work with `orchestrator-ci-env`.
+[`conf/orchestrator-ci-env.conf.json`](https://github.com/proxysql/orchestrator/blob/master/conf/orchestrator-ci-env.conf.json) is designed to work with `orchestrator-ci-env`.
 
 You may choose to change the value of `SQLite3DataFile`, which is by default on `/tmp`.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,7 +8,7 @@
 
 ## Build
 
-Running on pull requests, the [main CI](https://github.com/openark/orchestrator/blob/master/.github/workflows/main.yml) job validates the following:
+Running on pull requests, the [main CI](https://github.com/proxysql/orchestrator/blob/master/.github/workflows/main.yml) job validates the following:
 
 - Validate source code is formatted using `gofmt`
 - Build passes
@@ -18,18 +18,18 @@ Running on pull requests, the [main CI](https://github.com/openark/orchestrator/
   - Using `MySQL` backend
 - Documentation tests pass: ensuring pages and links are not orphaned.
 
-The [action](https://github.com/openark/orchestrator/actions?query=workflow%3ACI) completes by producing an artifact: an `orchestrator` binary for Linux `amd64`. The artifact is kept for a couple months per GitHub Actions policy.
+The [action](https://github.com/proxysql/orchestrator/actions?query=workflow%3ACI) completes by producing an artifact: an `orchestrator` binary for Linux `amd64`. The artifact is kept for a couple months per GitHub Actions policy.
 
 ## Upgrade
 
-[Upgrade](https://github.com/openark/orchestrator/blob/master/.github/workflows/upgrade.yml) runs on pull requests, tests a successful upgrade path from previous version (ie `master`) to PR's branch. This mainly tests internal database structure changes. The test:
+[Upgrade](https://github.com/proxysql/orchestrator/blob/master/.github/workflows/upgrade.yml) runs on pull requests, tests a successful upgrade path from previous version (ie `master`) to PR's branch. This mainly tests internal database structure changes. The test:
 
 - Checks out `master` and run `orchestrator`, once using `SQLite`, once using `MySQL`
 - Checks out `HEAD` (PR's branch) and run `orchestrator` using pre-existing `SQLite` and `MySQL` backends. Expect no error.
 
 ## System
 
-[System tests](https://github.com/openark/orchestrator/blob/master/.github/workflows/system.yml) run as a scheduled job. A system test:
+[System tests](https://github.com/proxysql/orchestrator/blob/master/.github/workflows/system.yml) run as a scheduled job. A system test:
 
 - Sets up a [CI environment](https://github.com/openark/orchestrator-ci-env) which includes:
   - A replication topology via [DBDeployer](https://www.dbdeployer.com/), with heartbeat injection

--- a/docs/configuration-discovery-pseudo-gtid.md
+++ b/docs/configuration-discovery-pseudo-gtid.md
@@ -58,4 +58,4 @@ If you wish to inject Pseudo-GTID yourself, we suggest you should configure as f
 The above assumes:
 
 - You have a `meta` schema
-- You will inject Pseudo-GTID entries via [this sample script](https://github.com/openark/orchestrator/tree/master/resources/pseudo-gtid)
+- You will inject Pseudo-GTID entries via [this sample script](https://github.com/proxysql/orchestrator/tree/master/resources/pseudo-gtid)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 Documenting and explaining all configuration variables turns to be a daunting task, as goes as deep as explain-the-code-in-words. There is an ongoing effort in pruning and simplifying the configuration.
 
-The de-facto configuration list is located in [config.go](https://github.com/openark/orchestrator/blob/master/go/config/config.go).
+The de-facto configuration list is located in [config.go](https://github.com/proxysql/orchestrator/blob/master/go/config/config.go).
 
 You are undoubtedly interested in configuring some basic components: the backend database, hosts discoveries. You may choose to use Pseudo-GTID. You may want `orchestrator` to notify upon failure, or you may wish to run full blown automated recovery.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -8,7 +8,7 @@ Multiple Dockerfiles are available, to:
 - Run a 3-node raft setup
 - Run a full blown CI environment
 
-[`script/dock`](https://github.com/openark/orchestrator/blob/master/script/dock) is a convenience script to build/spawn each of these docker images.
+[`script/dock`](https://github.com/proxysql/orchestrator/blob/master/script/dock) is a convenience script to build/spawn each of these docker images.
 
 ## Build and test
 
@@ -19,7 +19,7 @@ If you wish to build and test on your host, but do not want to set up a developm
 $ script/dock test
 ```
 
-This will use [`docker/Dockerfile.test`](https://github.com/openark/orchestrator/blob/master/docker/Dockerfile.test) to build, unit test, integration test, run doc validation on your behalf.
+This will use [`docker/Dockerfile.test`](https://github.com/proxysql/orchestrator/blob/master/docker/Dockerfile.test) to build, unit test, integration test, run doc validation on your behalf.
 
 ## Build and run
 
@@ -27,7 +27,7 @@ Run this command:
 ```shell
 $ script/dock alpine
 ```
-which uses [`docker/Dockerfile`](https://github.com/openark/orchestrator/blob/master/docker/Dockerfile) to build `orchestrator` on an Alpine Linux, and run the service. Docker will map port `:3000` onto your machine, you may browse onto `http://127.0.0.1:3000` to access the orchestrator web interface.
+which uses [`docker/Dockerfile`](https://github.com/proxysql/orchestrator/blob/master/docker/Dockerfile) to build `orchestrator` on an Alpine Linux, and run the service. Docker will map port `:3000` onto your machine, you may browse onto `http://127.0.0.1:3000` to access the orchestrator web interface.
 
 The following environment variables are available and take effect if no config
 file is bind mounted into container at `/etc/orchestrator.conf.json`
@@ -53,9 +53,9 @@ To create (via [`fpm`](https://fpm.readthedocs.io/en/latest/)) release packages:
 - `.rpm`
 - `.tgz`
 
-for Linux `amd64`, with `Systemd` or `SysVinit`, all binaries or just client scripts. It uses the same methods as used for [official releases](https://github.com/openark/orchestrator/releases).
+for Linux `amd64`, with `Systemd` or `SysVinit`, all binaries or just client scripts. It uses the same methods as used for [official releases](https://github.com/proxysql/orchestrator/releases).
 
-Uses [`Dockerfile.packaging`](https://github.com/openark/orchestrator/blob/master/docker/Dockerfile.packaging)
+Uses [`Dockerfile.packaging`](https://github.com/proxysql/orchestrator/blob/master/docker/Dockerfile.packaging)
 
 ## Run full CI environment
 
@@ -81,7 +81,7 @@ Tips:
   `mysqladmin -uci -pci -h 127.0.0.1 --port 13306 processlist`
 - Use `redeploy-ci-env` to re-create the MySQL topology, and recreate and restart the heartbeat, consul, consul-template and haproxy services. This resets the services to their original state.
 
-Uses [`Dockerfile.system`](https://github.com/openark/orchestrator/blob/master/docker/Dockerfile.system)
+Uses [`Dockerfile.system`](https://github.com/proxysql/orchestrator/blob/master/docker/Dockerfile.system)
 
 ## Run a raft setup
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -1,12 +1,12 @@
 # Download
 
-`orchestrator` is released as open source and is available at [GitHub](https://github.com/openark/orchestrator).
-Find official releases in https://github.com/openark/orchestrator/releases
+`orchestrator` is released as open source and is available at [GitHub](https://github.com/proxysql/orchestrator).
+Find official releases in https://github.com/proxysql/orchestrator/releases
 
 `orchestrator` packages can be found in https://packagecloud.io/github/orchestrator
 
 For developers: `orchestrator` is go-gettable. Issue:
 
-	go get github.com/openark/orchestrator/...
+	go get github.com/proxysql/orchestrator/...
 
 See [Orchestrator for developers](developers.md)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -87,7 +87,7 @@ No.
 
 ### Is orchestrator open source?
 
-Yes. `Orchestrator` is released as open source under the Apache License 2.0 and is available at: https://github.com/openark/orchestrator
+Yes. `Orchestrator` is released as open source under the Apache License 2.0 and is available at: https://github.com/proxysql/orchestrator
 
 ### Who develops orchestrator and why?
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,7 +9,7 @@ If not, replace `127.0.0.1` with appropriate host name. Replace `orch_backend_pa
 
 - Extract from tarball
 
-  Extract the archive you've downloaded from https://github.com/percona/orchestrator/tags
+  Extract the archive you've downloaded from https://github.com/proxysql/orchestrator/tags
   For example, let's assume you wish to install `orchestrator` under `/usr/local/orchestrator`:
 
       sudo mkdir -p /usr/local
@@ -45,7 +45,7 @@ Setup a MySQL server for backend, and invoke the following:
 `Orchestrator` uses a configuration file, located in either `/etc/orchestrator.conf.json` or relative path to binary `conf/orchestrator.conf.json` or
 `orchestrator.conf.json`.
 
-Tip: the installed package includes a file called `orchestrator.conf.json.sample` with some basic settings which you can use as baseline for `orchestrator.conf.json`. It is found in `/usr/local/orchestrator/orchestrator-sample.conf.json` and you may also find `/usr/local/orchestrator/orchestrator-sample-sqlite.conf.json` which has a SQLite-oriented configuration. Those sample files are also available [on the `orchestrator` repository](https://github.com/percona/orchestrator/tree/master/conf).
+Tip: the installed package includes a file called `orchestrator.conf.json.sample` with some basic settings which you can use as baseline for `orchestrator.conf.json`. It is found in `/usr/local/orchestrator/orchestrator-sample.conf.json` and you may also find `/usr/local/orchestrator/orchestrator-sample-sqlite.conf.json` which has a SQLite-oriented configuration. Those sample files are also available [on the `orchestrator` repository](https://github.com/proxysql/orchestrator/tree/master/conf).
 
 Edit `orchestrator.conf.json` to match the above as follows:
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,5 +1,5 @@
 `orchestrator` is released under the Apache License 2.0.
 
-See [LICENSE](https://github.com/openark/orchestrator/blob/master/LICENSE)
+See [LICENSE](https://github.com/proxysql/orchestrator/blob/master/LICENSE)
 
-This repository includes 3rd party libraries which have their own licenses. These libraries are found under https://github.com/openark/orchestrator/tree/master/vendor
+This repository includes 3rd party libraries which have their own licenses. These libraries are found under https://github.com/proxysql/orchestrator/tree/master/vendor

--- a/docs/orchestrator-client.md
+++ b/docs/orchestrator-client.md
@@ -1,6 +1,6 @@
 # orchestrator-client
 
-[orchestrator-client](https://github.com/openark/orchestrator/blob/master/resources/bin/orchestrator-client) is a script that wraps API calls with convenient command line interface.
+[orchestrator-client](https://github.com/proxysql/orchestrator/blob/master/resources/bin/orchestrator-client) is a script that wraps API calls with convenient command line interface.
 
 It can auto-determine the leader of an `orchestrator` setup and in such case forward all requests to the leader.
 

--- a/docs/pseudo-gtid-manual-injection.md
+++ b/docs/pseudo-gtid-manual-injection.md
@@ -18,7 +18,7 @@ for more detail.
 
 Injecting Pseudo GTID can be done via:
 - MySQL's [event_scheduler](https://dev.mysql.com/doc/refman/5.7/en/event-scheduler.html) (see examples below)
-- External injection, see [sample files](https://github.com/openark/orchestrator/tree/master/resources/pseudo-gtid):
+- External injection, see [sample files](https://github.com/proxysql/orchestrator/tree/master/resources/pseudo-gtid):
   - script to inject pseudo-gtid
   - start-stop script to serve as daemon on `/etc/init.d/pseudo-gtid`
   - a puppet module.

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -23,4 +23,4 @@ Failovers are inherently tied to your deployments through hooks.
 
 There's always risk with failovers. Make sure to test them.
 
-Please make sure to read the [LICENSE](https://github.com/openark/orchestrator/blob/master/LICENSE), and especially the "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND" part.
+Please make sure to read the [LICENSE](https://github.com/proxysql/orchestrator/blob/master/LICENSE), and especially the "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND" part.

--- a/docs/users.md
+++ b/docs/users.md
@@ -5,7 +5,7 @@ Question: Is orchestrator used by many people?
 Answer:  Right now there is no full list of people
 who are actively using it so it seemed like a good idea to generate a page
 of current users. If your name or your company's name is missing from this and
-you would like to be added please send a pull request to github.com/openark/orchestrator/pulls
+you would like to be added please send a pull request to github.com/proxysql/orchestrator/pulls
 
 Please keep this list in alphabetical order and include the company name and url and
 a short description of usage.

--- a/docs/using-the-web-api.md
+++ b/docs/using-the-web-api.md
@@ -22,9 +22,9 @@ By way of example:
 
 ### Full listing
 
-The de-facto listing is the code, please see [api.go](https://github.com/openark/orchestrator/blob/master/go/http/api.go) (scroll down to `RegisterRequests`).
+The de-facto listing is the code, please see [api.go](https://github.com/proxysql/orchestrator/blob/master/go/http/api.go) (scroll down to `RegisterRequests`).
 
-You may also appreciate looking at [orchestrator-client](orchestrator-client.md) ([source code](https://github.com/openark/orchestrator/blob/master/resources/bin/orchestrator-client)) to see how command line interface is translated to API calls.
+You may also appreciate looking at [orchestrator-client](orchestrator-client.md) ([source code](https://github.com/proxysql/orchestrator/blob/master/resources/bin/orchestrator-client)) to see how command line interface is translated to API calls.
 
 Or, just use the [orchestrator-client](orchestrator-client.md) as your API client, this is what it was made for.
 


### PR DESCRIPTION
## Summary

- Replace all `github.com/openark/orchestrator` references with `github.com/proxysql/orchestrator` across 15 docs files
- Replace all `github.com/percona/orchestrator` references with `github.com/proxysql/orchestrator` in `docs/install.md`
- Preserved references to separate repos (`openark/orchestrator-ci-env`, `openark/orchestrator-agent`)
- Did not modify `docs/superpowers/` files (specs and plans reference history correctly)

## Test plan

- [x] `grep -rn "openark/orchestrator" docs/ | grep -v "ci-env" | grep -v "superpowers"` returns empty
- [x] `grep -rn "percona/orchestrator" docs/ | grep -v "superpowers"` returns empty
- [x] `openark/orchestrator-ci-env` and `openark/orchestrator-agent` references are unchanged