### PR TITLE
Add code quality tooling (Makefile, golangci-lint)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,5 @@
 run:
   timeout: 5m
-  skip-dirs:
-    - vendor
 
 linters:
   disable-all: true
@@ -12,7 +10,3 @@ linters:
     - ineffassign
     - unused
     - gosimple
-
-issues:
-  exclude-dirs:
-    - vendor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,19 @@ go test ./go/inst/...
 go test ./go/inst/... -run TestBinlogCoordinates
 ```
 
+### Using the Makefile
+
+The project includes a root-level Makefile for common tasks:
+
+```bash
+make build      # Build bin/orchestrator
+make test       # Run unit tests
+make lint       # Run golangci-lint
+make fmt        # Format code with gofmt
+make check-fmt  # Check formatting (CI)
+make clean      # Remove build artifacts
+```
+
 See [docs/build.md](docs/build.md) for detailed build and test instructions.
 
 ## Code Review

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Build orchestrator binary
 build:
 	@mkdir -p bin
-	go build -o bin/orchestrator ./go/cmd/orchestrator/main.go
+	go build -o bin/orchestrator ./go/cmd/orchestrator
 
 # Run all unit tests
 test:


### PR DESCRIPTION
## Summary

- Add a root-level `Makefile` with targets: `build`, `test`, `lint`, `fmt`, `check-fmt`, `clean`
- Add `.golangci.yml` configuration with conservative linter set: `govet`, `staticcheck`, `errcheck`, `ineffassign`, `unused`, `gosimple`
- Linter timeout set to 5 minutes; vendor directory excluded

Contributors can now use `make build`, `make test`, `make lint`, and `make fmt` instead of remembering individual commands.

No lint fixes are included — this PR only sets up the tooling. Lint fixes will follow in separate PRs.

Closes #19

## Test plan

- [x] `make build` compiles `bin/orchestrator` successfully
- [x] `make test` runs the test suite
- [x] `make fmt` formats Go source files
- [x] `make check-fmt` exits cleanly when code is formatted
- [x] `make clean` removes build artifacts