### PR TITLE
Add release workflow for Docker and binary packages on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.25.7'
+        cache: true
+
+    - name: Build binary
+      run: go build -o bin/orchestrator ./go/cmd/orchestrator
+
+    - name: Create tar.gz archive
+      env:
+        TAG_NAME: ${{ github.ref_name }}
+      run: tar czf "orchestrator-${TAG_NAME}-linux-amd64.tar.gz" -C bin orchestrator
+
+    - name: Upload release assets
+      uses: softprops/action-gh-release@v2
+      with:
+        files: orchestrator-*.tar.gz
+        generate_release_notes: true
+        draft: false
+        prerelease: ${{ contains(github.ref_name, 'rc') }}
+
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/proxysql/orchestrator
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=raw,value=latest,enable=${{ !contains(github.ref_name, 'rc') }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        push: true
+        context: .
+        file: docker/Dockerfile
+        platforms: linux/amd64
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions release workflow (`.github/workflows/release.yml`) triggered on `v*` tag pushes
- **`build-and-release` job**: builds the Go binary, creates a `tar.gz` archive, and uploads it as a GitHub Release asset with auto-generated release notes. Tags containing `rc` are marked as pre-releases.
- **`docker` job**: builds the Docker image using `docker/Dockerfile`, pushes to GHCR (`ghcr.io/proxysql/orchestrator`) with semver tags. The `latest` tag is only applied for non-RC releases. Currently builds for `linux/amd64` only (arm64 requires CGO cross-compilation for SQLite).

Closes #23

## Test plan

- [ ] Push a test tag like `v0.0.1-rc1` and verify the workflow triggers
- [ ] Verify the binary tar.gz appears as a release asset
- [ ] Verify the GitHub Release is marked as pre-release for RC tags
- [ ] Verify Docker image is pushed to GHCR with correct tags
- [ ] Push a non-RC tag and verify `latest` tag is applied to the Docker image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated release workflow for building and publishing application binaries when version tags are pushed.
  * Docker container images are automatically built and published to the container registry.
  * Release artifacts are now automatically generated and published to GitHub Releases.
  * Prerelease versions are correctly identified and marked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->