### PR TITLE
Add ProxySQL topology query API

### DIFF
--- a/docs/proxysql-hooks.md
+++ b/docs/proxysql-hooks.md
@@ -87,6 +87,57 @@ orchestrator-client -c proxysql-test
 orchestrator-client -c proxysql-servers
 ```
 
+## Topology Query API
+
+Orchestrator exposes HTTP API endpoints for querying ProxySQL's runtime server list. These are useful for monitoring, debugging, and integration with other tools.
+
+### List all servers
+
+```
+GET /api/proxysql/servers
+```
+
+Returns all servers from ProxySQL's `runtime_mysql_servers` table:
+
+```json
+{
+  "Code": "OK",
+  "Message": "Found 4 servers",
+  "Details": [
+    {
+      "hostgroup_id": 10,
+      "hostname": "db1.example.com",
+      "port": 3306,
+      "status": "ONLINE",
+      "weight": 1000,
+      "max_connections": 100,
+      "comment": ""
+    }
+  ]
+}
+```
+
+### List servers by hostgroup
+
+```
+GET /api/proxysql/servers/:hostgroup
+```
+
+Returns servers filtered by hostgroup ID. Example:
+
+```bash
+curl http://localhost:3000/api/proxysql/servers/10
+```
+
+If ProxySQL is not configured, both endpoints return an error response:
+
+```json
+{
+  "Code": "ERROR",
+  "Message": "ProxySQL is not configured"
+}
+```
+
 ## Multiple ProxySQL Instances
 
 For ProxySQL Cluster deployments, configure orchestrator to connect to **one** ProxySQL node. Changes propagate automatically across the cluster via ProxySQL's built-in cluster synchronization (`proxysql_servers` table).

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -42,6 +42,7 @@ import (
 	"github.com/proxysql/orchestrator/go/logic"
 	"github.com/proxysql/orchestrator/go/metrics/query"
 	"github.com/proxysql/orchestrator/go/process"
+	"github.com/proxysql/orchestrator/go/proxysql"
 	orcraft "github.com/proxysql/orchestrator/go/raft"
 )
 
@@ -3762,6 +3763,41 @@ func (this *HttpAPI) registerSingleAPIRequest(m *martini.ClassicMartini, path st
 	}
 }
 
+// ProxySQLServers returns all servers from ProxySQL's runtime_mysql_servers table.
+func (this *HttpAPI) ProxySQLServers(params martini.Params, r render.Render, req *http.Request) {
+	hook := proxysql.GetHook()
+	if hook == nil || !hook.IsConfigured() {
+		Respond(r, &APIResponse{Code: ERROR, Message: "ProxySQL is not configured"})
+		return
+	}
+	servers, err := hook.GetClient().GetServers()
+	if err != nil {
+		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("Failed to query ProxySQL servers: %v", err)})
+		return
+	}
+	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Found %d servers", len(servers)), Details: servers})
+}
+
+// ProxySQLServersByHostgroup returns servers for a specific hostgroup from ProxySQL.
+func (this *HttpAPI) ProxySQLServersByHostgroup(params martini.Params, r render.Render, req *http.Request) {
+	hook := proxysql.GetHook()
+	if hook == nil || !hook.IsConfigured() {
+		Respond(r, &APIResponse{Code: ERROR, Message: "ProxySQL is not configured"})
+		return
+	}
+	hostgroupID, err := strconv.Atoi(params["hostgroup"])
+	if err != nil {
+		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("Invalid hostgroup ID: %v", err)})
+		return
+	}
+	servers, err := hook.GetClient().GetServersByHostgroup(hostgroupID)
+	if err != nil {
+		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("Failed to query ProxySQL servers: %v", err)})
+		return
+	}
+	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Found %d servers in hostgroup %d", len(servers), hostgroupID), Details: servers})
+}
+
 func (this *HttpAPI) registerAPIRequestInternal(m *martini.ClassicMartini, path string, handler martini.Handler, allowProxy bool) {
 	this.registerSingleAPIRequest(m, path, handler, allowProxy)
 
@@ -4047,6 +4083,10 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerAPIRequest(m, "agent-abort-seed/:seedId", this.AbortSeed)
 	this.registerAPIRequest(m, "agent-custom-command/:host/:command", this.AgentCustomCommand)
 	this.registerAPIRequest(m, "seeds", this.Seeds)
+
+	// ProxySQL topology
+	this.registerAPIRequest(m, "proxysql/servers", this.ProxySQLServers)
+	this.registerAPIRequest(m, "proxysql/servers/:hostgroup", this.ProxySQLServersByHostgroup)
 
 	// Configurable status check endpoint
 	if config.Config.StatusEndpoint == config.DefaultStatusAPIEndpoint {

--- a/go/proxysql/hook.go
+++ b/go/proxysql/hook.go
@@ -29,6 +29,14 @@ func (h *Hook) IsConfigured() bool {
 	return h.client != nil && h.writerHostgroup > 0
 }
 
+// GetClient returns the underlying ProxySQL client, or nil if the hook is not configured.
+func (h *Hook) GetClient() *Client {
+	if h == nil {
+		return nil
+	}
+	return h.client
+}
+
 func (h *Hook) PreFailover(oldMasterHost string, oldMasterPort int) error {
 	if !h.IsConfigured() {
 		return nil

--- a/go/proxysql/topology.go
+++ b/go/proxysql/topology.go
@@ -1,0 +1,80 @@
+package proxysql
+
+import (
+	"fmt"
+
+	"github.com/proxysql/golib/log"
+)
+
+// ServerEntry represents a row from ProxySQL's mysql_servers table.
+type ServerEntry struct {
+	HostgroupID int    `json:"hostgroup_id"`
+	Hostname    string `json:"hostname"`
+	Port        int    `json:"port"`
+	Status      string `json:"status"`
+	Weight      int    `json:"weight"`
+	MaxConns    int    `json:"max_connections"`
+	Comment     string `json:"comment"`
+}
+
+// GetServers queries runtime_mysql_servers from ProxySQL and returns all server entries.
+// Returns an empty slice (no error) if the client is nil.
+func (c *Client) GetServers() ([]ServerEntry, error) {
+	if c == nil {
+		return []ServerEntry{}, nil
+	}
+
+	query := "SELECT hostgroup_id, hostname, port, status, weight, max_connections, comment FROM runtime_mysql_servers ORDER BY hostgroup_id, hostname, port"
+	rows, db, err := c.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("proxysql: GetServers: %v", err)
+	}
+	defer db.Close()
+	defer rows.Close()
+
+	var servers []ServerEntry
+	for rows.Next() {
+		var s ServerEntry
+		if err := rows.Scan(&s.HostgroupID, &s.Hostname, &s.Port, &s.Status, &s.Weight, &s.MaxConns, &s.Comment); err != nil {
+			return nil, fmt.Errorf("proxysql: GetServers scan: %v", err)
+		}
+		servers = append(servers, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("proxysql: GetServers rows: %v", err)
+	}
+
+	log.Infof("proxysql: GetServers returned %d entries", len(servers))
+	return servers, nil
+}
+
+// GetServersByHostgroup returns servers filtered by hostgroup ID.
+// Returns an empty slice (no error) if the client is nil.
+func (c *Client) GetServersByHostgroup(hostgroupID int) ([]ServerEntry, error) {
+	if c == nil {
+		return []ServerEntry{}, nil
+	}
+
+	query := "SELECT hostgroup_id, hostname, port, status, weight, max_connections, comment FROM runtime_mysql_servers WHERE hostgroup_id = ? ORDER BY hostname, port"
+	rows, db, err := c.Query(query, hostgroupID)
+	if err != nil {
+		return nil, fmt.Errorf("proxysql: GetServersByHostgroup(%d): %v", hostgroupID, err)
+	}
+	defer db.Close()
+	defer rows.Close()
+
+	var servers []ServerEntry
+	for rows.Next() {
+		var s ServerEntry
+		if err := rows.Scan(&s.HostgroupID, &s.Hostname, &s.Port, &s.Status, &s.Weight, &s.MaxConns, &s.Comment); err != nil {
+			return nil, fmt.Errorf("proxysql: GetServersByHostgroup scan: %v", err)
+		}
+		servers = append(servers, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("proxysql: GetServersByHostgroup rows: %v", err)
+	}
+
+	log.Infof("proxysql: GetServersByHostgroup(%d) returned %d entries", hostgroupID, len(servers))
+	return servers, nil
+}

--- a/go/proxysql/topology_test.go
+++ b/go/proxysql/topology_test.go
@@ -1,0 +1,67 @@
+package proxysql
+
+import (
+	"testing"
+)
+
+func TestServerEntryStruct(t *testing.T) {
+	s := ServerEntry{
+		HostgroupID: 10,
+		Hostname:    "db1.example.com",
+		Port:        3306,
+		Status:      "ONLINE",
+		Weight:      1000,
+		MaxConns:    100,
+		Comment:     "primary writer",
+	}
+
+	if s.HostgroupID != 10 {
+		t.Errorf("expected HostgroupID=10, got %d", s.HostgroupID)
+	}
+	if s.Hostname != "db1.example.com" {
+		t.Errorf("expected Hostname=db1.example.com, got %s", s.Hostname)
+	}
+	if s.Port != 3306 {
+		t.Errorf("expected Port=3306, got %d", s.Port)
+	}
+	if s.Status != "ONLINE" {
+		t.Errorf("expected Status=ONLINE, got %s", s.Status)
+	}
+	if s.Weight != 1000 {
+		t.Errorf("expected Weight=1000, got %d", s.Weight)
+	}
+	if s.MaxConns != 100 {
+		t.Errorf("expected MaxConns=100, got %d", s.MaxConns)
+	}
+	if s.Comment != "primary writer" {
+		t.Errorf("expected Comment='primary writer', got '%s'", s.Comment)
+	}
+}
+
+func TestGetServersNilClient(t *testing.T) {
+	var c *Client
+	servers, err := c.GetServers()
+	if err != nil {
+		t.Errorf("expected no error for nil client, got %v", err)
+	}
+	if servers == nil {
+		t.Error("expected non-nil empty slice, got nil")
+	}
+	if len(servers) != 0 {
+		t.Errorf("expected empty slice, got %d entries", len(servers))
+	}
+}
+
+func TestGetServersByHostgroupNilClient(t *testing.T) {
+	var c *Client
+	servers, err := c.GetServersByHostgroup(10)
+	if err != nil {
+		t.Errorf("expected no error for nil client, got %v", err)
+	}
+	if servers == nil {
+		t.Error("expected non-nil empty slice, got nil")
+	}
+	if len(servers) != 0 {
+		t.Errorf("expected empty slice, got %d entries", len(servers))
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ServerEntry` struct and `GetServers()`/`GetServersByHostgroup()` query methods to the ProxySQL client package
- Expose two new HTTP API endpoints: `GET /api/proxysql/servers` and `GET /api/proxysql/servers/:hostgroup`
- Add `GetClient()` accessor to `Hook` for use by the HTTP layer
- Document the new topology API endpoints in `docs/proxysql-hooks.md`

Closes #31

## Test plan

- [x] `go build` succeeds
- [x] `go test ./go/proxysql/... -v` passes (10 tests including new topology tests)
- [ ] Manual test with a running ProxySQL instance to verify server list queries
- [ ] Verify API returns proper error when ProxySQL is not configured