### PR TITLE
Add versioned REST API v2 with structured responses

### DIFF
--- a/docs/api-v2.md
+++ b/docs/api-v2.md
@@ -1,0 +1,307 @@
+# API v2
+
+Orchestrator provides a versioned REST API at `/api/v2/` with consistent structured JSON responses.
+
+The v1 API (`/api/`) remains fully available and is not deprecated. The v2 API provides a standardized response envelope and proper HTTP status codes.
+
+## Response Envelope
+
+All v2 endpoints return responses in a standard JSON envelope:
+
+### Success response
+
+```json
+{
+  "status": "ok",
+  "data": { ... },
+  "message": "optional human-readable message"
+}
+```
+
+### Error response
+
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "MACHINE_READABLE_CODE",
+    "message": "Human-readable error description"
+  }
+}
+```
+
+Fields with empty/nil values are omitted from the response (`omitempty`).
+
+### HTTP Status Codes
+
+Unlike the v1 API which returns 200 for most responses, v2 uses proper HTTP status codes:
+
+| Code | Meaning |
+|------|---------|
+| 200  | Success |
+| 400  | Bad request (invalid parameters) |
+| 404  | Resource not found |
+| 500  | Internal server error |
+| 503  | Service unavailable (unhealthy) |
+
+### Error Codes
+
+| Code | Description |
+|------|-------------|
+| `NOT_FOUND` | The requested resource does not exist |
+| `INVALID_PARAMS` | Request parameters are invalid |
+| `INTERNAL_ERROR` | An internal server error occurred |
+| `UNHEALTHY` | The orchestrator node is unhealthy |
+| `NOT_CONFIGURED` | A required component is not configured |
+
+## Endpoints
+
+### Clusters
+
+#### `GET /api/v2/clusters`
+
+List all known clusters with metadata.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "data": [
+    {
+      "ClusterName": "myhost:3306",
+      "ClusterAlias": "mycluster",
+      "ClusterDomain": "",
+      "CountInstances": 3,
+      "HeuristicLag": 0,
+      "HasAutomatedMasterRecovery": true,
+      "HasAutomatedIntermediateMasterRecovery": true
+    }
+  ]
+}
+```
+
+#### `GET /api/v2/clusters/{alias}`
+
+Get detailed info for one cluster, looked up by alias or cluster name.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "data": {
+    "ClusterName": "myhost:3306",
+    "ClusterAlias": "mycluster",
+    "CountInstances": 3
+  }
+}
+```
+
+**Error (404):**
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Cluster not found: unknown-alias"
+  }
+}
+```
+
+#### `GET /api/v2/clusters/{alias}/instances`
+
+List all instances belonging to a cluster.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "data": [
+    {
+      "Key": {"Hostname": "myhost", "Port": 3306},
+      "ClusterName": "myhost:3306",
+      "IsReplica": false,
+      "ReplicationDepth": 0
+    }
+  ]
+}
+```
+
+### Instances
+
+#### `GET /api/v2/instances/{host}/{port}`
+
+Get detailed information about a single MySQL instance.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "data": {
+    "Key": {"Hostname": "myhost", "Port": 3306},
+    "Uptime": 86400,
+    "ClusterName": "myhost:3306",
+    "IsReplica": false,
+    "ReplicationDepth": 0,
+    "Replicas": []
+  }
+}
+```
+
+**Error (404):**
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Instance not found: myhost:3306"
+  }
+}
+```
+
+**Error (400):**
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "INVALID_PARAMS",
+    "message": "Invalid instance key: badhost:badport"
+  }
+}
+```
+
+### Topology
+
+#### `GET /api/v2/topology/{clusterAlias}`
+
+Returns the topology (instances with replication relationships) for a cluster. The response contains all instances in the cluster; replication relationships can be derived from each instance's `MasterKey` and `Replicas` fields.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "data": [
+    {
+      "Key": {"Hostname": "master", "Port": 3306},
+      "MasterKey": {"Hostname": "", "Port": 0},
+      "Replicas": [{"Hostname": "replica1", "Port": 3306}],
+      "ReplicationDepth": 0
+    },
+    {
+      "Key": {"Hostname": "replica1", "Port": 3306},
+      "MasterKey": {"Hostname": "master", "Port": 3306},
+      "Replicas": [],
+      "ReplicationDepth": 1
+    }
+  ]
+}
+```
+
+### Recoveries
+
+#### `GET /api/v2/recoveries`
+
+List recent recovery entries. Supports optional query parameters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `cluster` | string | Filter by cluster name |
+| `alias` | string | Filter by cluster alias |
+| `unacknowledged` | boolean | If `true`, only show unacknowledged recoveries |
+| `page` | integer | Page number for pagination (0-indexed) |
+
+**Example:** `GET /api/v2/recoveries?cluster=myhost:3306&unacknowledged=true`
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "data": [
+    {
+      "Id": 1,
+      "AnalysisEntry": { ... },
+      "SuccessorKey": {"Hostname": "new-master", "Port": 3306},
+      "IsActive": false,
+      "IsSuccessful": true
+    }
+  ]
+}
+```
+
+#### `GET /api/v2/recoveries/active`
+
+Returns currently active (in-progress) recoveries.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "data": []
+}
+```
+
+### Health / Status
+
+#### `GET /api/v2/status`
+
+Returns orchestrator node health and status information.
+
+**Success Response (200):**
+```json
+{
+  "status": "ok",
+  "data": {
+    "Healthy": true,
+    "Hostname": "orch-node-1",
+    "Token": "abc123",
+    "IsActiveNode": true,
+    "RaftLeader": "",
+    "IsRaftLeader": false
+  },
+  "message": "Application node is healthy"
+}
+```
+
+**Unhealthy Response (503):**
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "UNHEALTHY",
+    "message": "Application node is unhealthy: ..."
+  }
+}
+```
+
+### ProxySQL
+
+#### `GET /api/v2/proxysql/servers`
+
+Returns ProxySQL server entries from the runtime_mysql_servers table.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "data": [
+    {
+      "Hostgroup": 10,
+      "Hostname": "myhost",
+      "Port": 3306,
+      "Status": "ONLINE",
+      "Weight": 1000
+    }
+  ],
+  "message": "Found 1 servers"
+}
+```
+
+**Error (404 - not configured):**
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "NOT_CONFIGURED",
+    "message": "ProxySQL is not configured"
+  }
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
 	github.com/fatih/color v1.19.0 // indirect
+	github.com/go-chi/chi/v5 v5.2.5 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=

--- a/go/app/http.go
+++ b/go/app/http.go
@@ -32,6 +32,7 @@ import (
 	"github.com/proxysql/orchestrator/go/process"
 	"github.com/proxysql/orchestrator/go/ssl"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/go-martini/martini"
 	"github.com/martini-contrib/auth"
 	"github.com/martini-contrib/gzip"
@@ -137,6 +138,11 @@ func standardHttp(continuousDiscovery bool) {
 	http.API.RegisterRequests(m)
 	http.Web.RegisterRequests(m)
 
+	// Register v2 API routes on a chi router, composed with the martini handler
+	v2Router := chi.NewRouter()
+	v2Router.Mount(config.Config.URLPrefix+"/api/v2", http.RegisterV2Routes())
+	handler := composeHandlers(v2Router, m)
+
 	// Serve
 	if config.Config.ListenSocket != "" {
 		log.Infof("Starting HTTP listener on unix socket %v", config.Config.ListenSocket)
@@ -145,7 +151,7 @@ func standardHttp(continuousDiscovery bool) {
 			log.Fatale(err)
 		}
 		defer unixListener.Close()
-		if err := nethttp.Serve(unixListener, m); err != nil {
+		if err := nethttp.Serve(unixListener, handler); err != nil {
 			log.Fatale(err)
 		}
 	} else if config.Config.UseSSL {
@@ -158,12 +164,12 @@ func standardHttp(continuousDiscovery bool) {
 		if err = ssl.AppendKeyPairWithPassword(tlsConfig, config.Config.SSLCertFile, config.Config.SSLPrivateKeyFile, sslPEMPassword); err != nil {
 			log.Fatale(err)
 		}
-		if err = ssl.ListenAndServeTLS(config.Config.ListenAddress, m, tlsConfig); err != nil {
+		if err = ssl.ListenAndServeTLS(config.Config.ListenAddress, handler, tlsConfig); err != nil {
 			log.Fatale(err)
 		}
 	} else {
 		log.Infof("Starting HTTP listener on %+v", config.Config.ListenAddress)
-		if err := nethttp.ListenAndServe(config.Config.ListenAddress, m); err != nil {
+		if err := nethttp.ListenAndServe(config.Config.ListenAddress, handler); err != nil {
 			log.Fatale(err)
 		}
 	}
@@ -208,4 +214,20 @@ func agentsHttp() {
 		}
 	}
 	log.Info("Agent server started")
+}
+
+// composeHandlers returns an http.Handler that tries the v2 chi router first,
+// falling back to the martini handler for all other requests. Chi returns 405
+// for matched routes with wrong methods, so we only intercept when chi has a
+// matching route (non-404/405 response).
+func composeHandlers(v2 *chi.Mux, fallback nethttp.Handler) nethttp.Handler {
+	return nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		// Check if chi has a matching route
+		rctx := chi.NewRouteContext()
+		if v2.Match(rctx, r.Method, r.URL.Path) {
+			v2.ServeHTTP(w, r)
+			return
+		}
+		fallback.ServeHTTP(w, r)
+	})
 }

--- a/go/http/apiv2.go
+++ b/go/http/apiv2.go
@@ -1,0 +1,265 @@
+/*
+   Copyright 2026 Percona LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/proxysql/orchestrator/go/inst"
+	"github.com/proxysql/orchestrator/go/logic"
+	"github.com/proxysql/orchestrator/go/process"
+	"github.com/proxysql/orchestrator/go/proxysql"
+)
+
+// V2APIResponse is the standard v2 response envelope
+type V2APIResponse struct {
+	Status  string      `json:"status"`           // "ok" or "error"
+	Data    interface{} `json:"data,omitempty"`    // response payload
+	Error   *V2APIError `json:"error,omitempty"`   // error details
+	Message string      `json:"message,omitempty"` // human-readable message
+}
+
+// V2APIError contains machine-readable error details
+type V2APIError struct {
+	Code    string `json:"code"`    // machine-readable error code
+	Message string `json:"message"` // human-readable error description
+}
+
+// respondOK writes a 200 JSON response with the standard v2 envelope.
+func respondOK(w http.ResponseWriter, data interface{}) {
+	writeV2JSON(w, http.StatusOK, V2APIResponse{
+		Status: "ok",
+		Data:   data,
+	})
+}
+
+// respondOKWithMessage writes a 200 JSON response with data and a message.
+func respondOKWithMessage(w http.ResponseWriter, data interface{}, message string) {
+	writeV2JSON(w, http.StatusOK, V2APIResponse{
+		Status:  "ok",
+		Data:    data,
+		Message: message,
+	})
+}
+
+// respondError writes an error JSON response with the given HTTP status code.
+func respondError(w http.ResponseWriter, status int, code, message string) {
+	writeV2JSON(w, status, V2APIResponse{
+		Status: "error",
+		Error: &V2APIError{
+			Code:    code,
+			Message: message,
+		},
+	})
+}
+
+// respondNotFound writes a 404 JSON response.
+func respondNotFound(w http.ResponseWriter, message string) {
+	respondError(w, http.StatusNotFound, "NOT_FOUND", message)
+}
+
+// writeV2JSON marshals the response and writes it with the given status code.
+func writeV2JSON(w http.ResponseWriter, status int, resp V2APIResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(resp)
+}
+
+// RegisterV2Routes returns a chi.Router with all v2 API routes.
+func RegisterV2Routes() chi.Router {
+	r := chi.NewRouter()
+
+	// Cluster endpoints
+	r.Get("/clusters", V2Clusters)
+	r.Get("/clusters/{alias}", V2ClusterInfo)
+	r.Get("/clusters/{alias}/instances", V2ClusterInstances)
+
+	// Instance endpoints
+	r.Get("/instances/{host}/{port}", V2Instance)
+
+	// Topology endpoints
+	r.Get("/topology/{clusterAlias}", V2Topology)
+
+	// Recovery endpoints
+	r.Get("/recoveries", V2Recoveries)
+	r.Get("/recoveries/active", V2ActiveRecoveries)
+
+	// Health/status
+	r.Get("/status", V2Status)
+
+	// ProxySQL
+	r.Get("/proxysql/servers", V2ProxySQLServers)
+
+	return r
+}
+
+// V2Clusters returns a list of all known clusters with metadata.
+func V2Clusters(w http.ResponseWriter, r *http.Request) {
+	clustersInfo, err := inst.ReadClustersInfo("")
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "INTERNAL_ERROR",
+			fmt.Sprintf("Failed to read clusters: %v", err))
+		return
+	}
+	respondOK(w, clustersInfo)
+}
+
+// V2ClusterInfo returns detailed info for one cluster, looked up by alias.
+func V2ClusterInfo(w http.ResponseWriter, r *http.Request) {
+	alias := chi.URLParam(r, "alias")
+	clusterName, err := inst.GetClusterByAlias(alias)
+	if err != nil {
+		// Try treating the alias as a cluster name directly
+		clusterName = alias
+	}
+	clusterInfo, err := inst.ReadClusterInfo(clusterName)
+	if err != nil {
+		respondNotFound(w, fmt.Sprintf("Cluster not found: %s", alias))
+		return
+	}
+	respondOK(w, clusterInfo)
+}
+
+// V2ClusterInstances returns all instances belonging to a cluster.
+func V2ClusterInstances(w http.ResponseWriter, r *http.Request) {
+	alias := chi.URLParam(r, "alias")
+	clusterName, err := inst.GetClusterByAlias(alias)
+	if err != nil {
+		clusterName = alias
+	}
+	instances, err := inst.ReadClusterInstances(clusterName)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "INTERNAL_ERROR",
+			fmt.Sprintf("Failed to read cluster instances: %v", err))
+		return
+	}
+	if len(instances) == 0 {
+		respondNotFound(w, fmt.Sprintf("No instances found for cluster: %s", alias))
+		return
+	}
+	respondOK(w, instances)
+}
+
+// V2Instance returns detailed information about a single instance.
+func V2Instance(w http.ResponseWriter, r *http.Request) {
+	host := chi.URLParam(r, "host")
+	port := chi.URLParam(r, "port")
+
+	instanceKey, err := inst.NewResolveInstanceKeyStrings(host, port)
+	if err != nil {
+		respondError(w, http.StatusBadRequest, "INVALID_PARAMS",
+			fmt.Sprintf("Invalid instance key: %s:%s", host, port))
+		return
+	}
+	instance, found, err := inst.ReadInstance(instanceKey)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "INTERNAL_ERROR",
+			fmt.Sprintf("Failed to read instance: %v", err))
+		return
+	}
+	if !found {
+		respondNotFound(w, fmt.Sprintf("Instance not found: %s:%s", host, port))
+		return
+	}
+	respondOK(w, instance)
+}
+
+// V2Topology returns the topology (instances with replication relationships) for a cluster.
+func V2Topology(w http.ResponseWriter, r *http.Request) {
+	clusterAlias := chi.URLParam(r, "clusterAlias")
+	clusterName, err := inst.GetClusterByAlias(clusterAlias)
+	if err != nil {
+		clusterName = clusterAlias
+	}
+	instances, err := inst.ReadClusterInstances(clusterName)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "INTERNAL_ERROR",
+			fmt.Sprintf("Failed to read topology: %v", err))
+		return
+	}
+	if len(instances) == 0 {
+		respondNotFound(w, fmt.Sprintf("No topology found for cluster: %s", clusterAlias))
+		return
+	}
+	respondOK(w, instances)
+}
+
+// V2Recoveries returns recent recovery entries. Supports optional query parameters:
+// ?cluster=<name>&page=<n>&unacknowledged=true
+func V2Recoveries(w http.ResponseWriter, r *http.Request) {
+	clusterName := r.URL.Query().Get("cluster")
+	clusterAlias := r.URL.Query().Get("alias")
+	unacknowledgedOnly := r.URL.Query().Get("unacknowledged") == "true"
+	page := 0
+	if pageStr := r.URL.Query().Get("page"); pageStr != "" {
+		if p, err := strconv.Atoi(pageStr); err == nil && p >= 0 {
+			page = p
+		}
+	}
+
+	recoveries, err := logic.ReadRecentRecoveries(clusterName, clusterAlias, unacknowledgedOnly, page)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "INTERNAL_ERROR",
+			fmt.Sprintf("Failed to read recoveries: %v", err))
+		return
+	}
+	respondOK(w, recoveries)
+}
+
+// V2ActiveRecoveries returns currently active (in-progress) recoveries.
+func V2ActiveRecoveries(w http.ResponseWriter, r *http.Request) {
+	recoveries, err := logic.ReadActiveRecoveries()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "INTERNAL_ERROR",
+			fmt.Sprintf("Failed to read active recoveries: %v", err))
+		return
+	}
+	respondOK(w, recoveries)
+}
+
+// V2Status returns orchestrator health and status information.
+func V2Status(w http.ResponseWriter, r *http.Request) {
+	health, err := process.HealthTest()
+	if err != nil {
+		respondError(w, http.StatusServiceUnavailable, "UNHEALTHY",
+			fmt.Sprintf("Application node is unhealthy: %v", err))
+		return
+	}
+	respondOKWithMessage(w, health, "Application node is healthy")
+}
+
+// V2ProxySQLServers returns ProxySQL server entries.
+func V2ProxySQLServers(w http.ResponseWriter, r *http.Request) {
+	hook := proxysql.GetHook()
+	if hook == nil || !hook.IsConfigured() {
+		respondError(w, http.StatusNotFound, "NOT_CONFIGURED",
+			"ProxySQL is not configured")
+		return
+	}
+	servers, err := hook.GetClient().GetServers()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "INTERNAL_ERROR",
+			fmt.Sprintf("Failed to query ProxySQL servers: %v", err))
+		return
+	}
+	respondOKWithMessage(w, servers, fmt.Sprintf("Found %d servers", len(servers)))
+}

--- a/go/http/apiv2_test.go
+++ b/go/http/apiv2_test.go
@@ -1,0 +1,204 @@
+/*
+   Copyright 2026 Percona LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRespondOK(t *testing.T) {
+	w := httptest.NewRecorder()
+	data := map[string]string{"key": "value"}
+	respondOK(w, data)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %s", ct)
+	}
+
+	var resp V2APIResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.Status != "ok" {
+		t.Errorf("expected status 'ok', got '%s'", resp.Status)
+	}
+	if resp.Error != nil {
+		t.Errorf("expected nil error, got %+v", resp.Error)
+	}
+	if resp.Data == nil {
+		t.Error("expected data to be non-nil")
+	}
+	// Verify the data content
+	dataMap, ok := resp.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected data to be a map, got %T", resp.Data)
+	}
+	if dataMap["key"] != "value" {
+		t.Errorf("expected data[key]='value', got '%v'", dataMap["key"])
+	}
+}
+
+func TestRespondOKWithMessage(t *testing.T) {
+	w := httptest.NewRecorder()
+	respondOKWithMessage(w, []int{1, 2, 3}, "found items")
+
+	var resp V2APIResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.Status != "ok" {
+		t.Errorf("expected status 'ok', got '%s'", resp.Status)
+	}
+	if resp.Message != "found items" {
+		t.Errorf("expected message 'found items', got '%s'", resp.Message)
+	}
+	if resp.Data == nil {
+		t.Error("expected data to be non-nil")
+	}
+}
+
+func TestRespondError(t *testing.T) {
+	w := httptest.NewRecorder()
+	respondError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "something went wrong")
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", w.Code)
+	}
+
+	var resp V2APIResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.Status != "error" {
+		t.Errorf("expected status 'error', got '%s'", resp.Status)
+	}
+	if resp.Data != nil {
+		t.Errorf("expected nil data on error, got %+v", resp.Data)
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error field to be non-nil")
+	}
+	if resp.Error.Code != "INTERNAL_ERROR" {
+		t.Errorf("expected error code 'INTERNAL_ERROR', got '%s'", resp.Error.Code)
+	}
+	if resp.Error.Message != "something went wrong" {
+		t.Errorf("expected error message 'something went wrong', got '%s'", resp.Error.Message)
+	}
+}
+
+func TestRespondNotFound(t *testing.T) {
+	w := httptest.NewRecorder()
+	respondNotFound(w, "resource not found")
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", w.Code)
+	}
+
+	var resp V2APIResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.Status != "error" {
+		t.Errorf("expected status 'error', got '%s'", resp.Status)
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error field to be non-nil")
+	}
+	if resp.Error.Code != "NOT_FOUND" {
+		t.Errorf("expected error code 'NOT_FOUND', got '%s'", resp.Error.Code)
+	}
+	if resp.Error.Message != "resource not found" {
+		t.Errorf("expected error message 'resource not found', got '%s'", resp.Error.Message)
+	}
+}
+
+func TestRespondErrorBadRequest(t *testing.T) {
+	w := httptest.NewRecorder()
+	respondError(w, http.StatusBadRequest, "INVALID_PARAMS", "bad input")
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", w.Code)
+	}
+
+	var resp V2APIResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.Status != "error" {
+		t.Errorf("expected status 'error', got '%s'", resp.Status)
+	}
+	if resp.Error.Code != "INVALID_PARAMS" {
+		t.Errorf("expected error code 'INVALID_PARAMS', got '%s'", resp.Error.Code)
+	}
+}
+
+func TestResponseEnvelopeOmitsNilFields(t *testing.T) {
+	w := httptest.NewRecorder()
+	respondOK(w, "hello")
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	// "error" should be omitted (omitempty)
+	if _, exists := raw["error"]; exists {
+		t.Error("expected 'error' field to be omitted when nil")
+	}
+	// "message" should be omitted when empty
+	if _, exists := raw["message"]; exists {
+		t.Error("expected 'message' field to be omitted when empty")
+	}
+	// "data" should be present
+	if _, exists := raw["data"]; !exists {
+		t.Error("expected 'data' field to be present")
+	}
+	// "status" should be present
+	if _, exists := raw["status"]; !exists {
+		t.Error("expected 'status' field to be present")
+	}
+}
+
+func TestResponseEnvelopeErrorOmitsData(t *testing.T) {
+	w := httptest.NewRecorder()
+	respondError(w, http.StatusInternalServerError, "ERR", "fail")
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	// "data" should be omitted on error
+	if _, exists := raw["data"]; exists {
+		t.Error("expected 'data' field to be omitted on error")
+	}
+	// "error" should be present
+	if _, exists := raw["error"]; !exists {
+		t.Error("expected 'error' field to be present")
+	}
+}
+
+func TestRegisterV2Routes(t *testing.T) {
+	router := RegisterV2Routes()
+	if router == nil {
+		t.Fatal("expected non-nil router from RegisterV2Routes")
+	}
+}

--- a/vendor/github.com/go-chi/chi/v5/.gitignore
+++ b/vendor/github.com/go-chi/chi/v5/.gitignore
@@ -1,0 +1,3 @@
+.idea
+*.sw?
+.vscode

--- a/vendor/github.com/go-chi/chi/v5/CHANGELOG.md
+++ b/vendor/github.com/go-chi/chi/v5/CHANGELOG.md
@@ -1,0 +1,341 @@
+# Changelog
+
+## v5.0.12 (2024-02-16)
+
+- History of changes: see https://github.com/go-chi/chi/compare/v5.0.11...v5.0.12
+
+
+## v5.0.11 (2023-12-19)
+
+- History of changes: see https://github.com/go-chi/chi/compare/v5.0.10...v5.0.11
+
+
+## v5.0.10 (2023-07-13)
+
+- Fixed small edge case in tests of v5.0.9 for older Go versions
+- History of changes: see https://github.com/go-chi/chi/compare/v5.0.9...v5.0.10
+
+
+## v5.0.9 (2023-07-13)
+
+- History of changes: see https://github.com/go-chi/chi/compare/v5.0.8...v5.0.9
+
+
+## v5.0.8 (2022-12-07)
+
+- History of changes: see https://github.com/go-chi/chi/compare/v5.0.7...v5.0.8
+
+
+## v5.0.7 (2021-11-18)
+
+- History of changes: see https://github.com/go-chi/chi/compare/v5.0.6...v5.0.7
+
+
+## v5.0.6 (2021-11-15)
+
+- History of changes: see https://github.com/go-chi/chi/compare/v5.0.5...v5.0.6
+
+
+## v5.0.5 (2021-10-27)
+
+- History of changes: see https://github.com/go-chi/chi/compare/v5.0.4...v5.0.5
+
+
+## v5.0.4 (2021-08-29)
+
+- History of changes: see https://github.com/go-chi/chi/compare/v5.0.3...v5.0.4
+
+
+## v5.0.3 (2021-04-29)
+
+- History of changes: see https://github.com/go-chi/chi/compare/v5.0.2...v5.0.3
+
+
+## v5.0.2 (2021-03-25)
+
+- History of changes: see https://github.com/go-chi/chi/compare/v5.0.1...v5.0.2
+
+
+## v5.0.1 (2021-03-10)
+
+- Small improvements
+- History of changes: see https://github.com/go-chi/chi/compare/v5.0.0...v5.0.1
+
+
+## v5.0.0 (2021-02-27)
+
+- chi v5, `github.com/go-chi/chi/v5` introduces the adoption of Go's SIV to adhere to the current state-of-the-tools in Go.
+- chi v1.5.x did not work out as planned, as the Go tooling is too powerful and chi's adoption is too wide.
+  The most responsible thing to do for everyone's benefit is to just release v5 with SIV, so I present to you all,
+  chi v5 at `github.com/go-chi/chi/v5`. I hope someday the developer experience and ergonomics I've been seeking
+  will still come to fruition in some form, see https://github.com/golang/go/issues/44550
+- History of changes: see https://github.com/go-chi/chi/compare/v1.5.4...v5.0.0
+
+
+## v1.5.4 (2021-02-27)
+
+- Undo prior retraction in v1.5.3 as we prepare for v5.0.0 release
+- History of changes: see https://github.com/go-chi/chi/compare/v1.5.3...v1.5.4
+
+
+## v1.5.3 (2021-02-21)
+
+- Update go.mod to go 1.16 with new retract directive marking all versions without prior go.mod support
+- History of changes: see https://github.com/go-chi/chi/compare/v1.5.2...v1.5.3
+
+
+## v1.5.2 (2021-02-10)
+
+- Reverting allocation optimization as a precaution as go test -race fails.
+- Minor improvements, see history below
+- History of changes: see https://github.com/go-chi/chi/compare/v1.5.1...v1.5.2
+
+
+## v1.5.1 (2020-12-06)
+
+- Performance improvement: removing 1 allocation by foregoing context.WithValue, thank you @bouk for
+  your contribution (https://github.com/go-chi/chi/pull/555). Note: new benchmarks posted in README.
+- `middleware.CleanPath`: new middleware that clean's request path of double slashes
+- deprecate & remove `chi.ServerBaseContext` in favour of stdlib `http.Server#BaseContext`
+- plus other tiny improvements, see full commit history below
+- History of changes: see https://github.com/go-chi/chi/compare/v4.1.2...v1.5.1
+
+
+## v1.5.0 (2020-11-12) - now with go.mod support
+
+`chi` dates back to 2016 with it's original implementation as one of the first routers to adopt the newly introduced
+context.Context api to the stdlib -- set out to design a router that is faster, more modular and simpler than anything
+else out there -- while not introducing any custom handler types or dependencies. Today, `chi` still has zero dependencies,
+and in many ways is future proofed from changes, given it's minimal nature. Between versions, chi's iterations have been very
+incremental, with the architecture and api being the same today as it was originally designed in 2016. For this reason it 
+makes chi a pretty easy project to maintain, as well thanks to the many amazing community contributions over the years
+to who all help make chi better (total of 86 contributors to date -- thanks all!).
+
+Chi has been a labour of love, art and engineering, with the goals to offer beautiful ergonomics, flexibility, performance
+and simplicity when building HTTP services with Go. I've strived to keep the router very minimal in surface area / code size,
+and always improving the code wherever possible -- and as of today the `chi` package is just 1082 lines of code (not counting
+middlewares, which are all optional). As well, I don't have the exact metrics, but from my analysis and email exchanges from
+companies and developers, chi is used by thousands of projects around the world -- thank you all as there is no better form of
+joy for me than to have art I had started be helpful and enjoyed by others. And of course I use chi in all of my own projects too :)
+
+For me, the aesthetics of chi's code and usage are very important. With the introduction of Go's module support
+(which I'm a big fan of), chi's past versioning scheme choice to v2, v3 and v4 would mean I'd require the import path
+of "github.com/go-chi/chi/v4", leading to the lengthy discussion at https://github.com/go-chi/chi/issues/462.
+Haha, to some, you may be scratching your head why I've spent > 1 year stalling to adopt "/vXX" convention in the import
+path -- which isn't horrible in general -- but for chi, I'm unable to accept it as I strive for perfection in it's API design,
+aesthetics and simplicity. It just doesn't feel good to me given chi's simple nature -- I do not foresee a "v5" or "v6",
+and upgrading between versions in the future will also be just incremental.
+
+I do understand versioning is a part of the API design as well, which is why the solution for a while has been to "do nothing",
+as Go supports both old and new import paths with/out go.mod. However, now that Go module support has had time to iron out kinks and
+is adopted everywhere, it's time for chi to get with the times. Luckily, I've discovered a path forward that will make me happy,
+while also not breaking anyone's app who adopted a prior versioning from tags in v2/v3/v4. I've made an experimental release of
+v1.5.0 with go.mod silently, and tested it with new and old projects, to ensure the developer experience is preserved, and it's
+largely unnoticed. Fortunately, Go's toolchain will check the tags of a repo and consider the "latest" tag the one with go.mod.
+However, you can still request a specific older tag such as v4.1.2, and everything will "just work". But new users can just
+`go get github.com/go-chi/chi` or `go get github.com/go-chi/chi@latest` and they will get the latest version which contains
+go.mod support, which is v1.5.0+. `chi` will not change very much over the years, just like it hasn't changed much from 4 years ago.
+Therefore, we will stay on v1.x from here on, starting from v1.5.0. Any breaking changes will bump a "minor" release and
+backwards-compatible improvements/fixes will bump a "tiny" release.
+
+For existing projects who want to upgrade to the latest go.mod version, run: `go get -u github.com/go-chi/chi@v1.5.0`,
+which will get you on the go.mod version line (as Go's mod cache may still remember v4.x). Brand new systems can run
+`go get -u github.com/go-chi/chi` or `go get -u github.com/go-chi/chi@latest` to install chi, which will install v1.5.0+
+built with go.mod support.
+
+My apologies to the developers who will disagree with the decisions above, but, hope you'll try it and see it's a very
+minor request which is backwards compatible and won't break your existing installations.
+
+Cheers all, happy coding!
+
+
+---
+
+
+## v4.1.2 (2020-06-02)
+
+- fix that handles MethodNotAllowed with path variables, thank you @caseyhadden for your contribution
+- fix to replace nested wildcards correctly in RoutePattern, thank you @@unmultimedio for your contribution
+- History of changes: see https://github.com/go-chi/chi/compare/v4.1.1...v4.1.2
+
+
+## v4.1.1 (2020-04-16)
+
+- fix for issue https://github.com/go-chi/chi/issues/411 which allows for overlapping regexp
+  route to the correct handler through a recursive tree search, thanks to @Jahaja for the PR/fix!
+- new middleware.RouteHeaders as a simple router for request headers with wildcard support
+- History of changes: see https://github.com/go-chi/chi/compare/v4.1.0...v4.1.1
+
+
+## v4.1.0 (2020-04-1)
+
+- middleware.LogEntry: Write method on interface now passes the response header
+  and an extra interface type useful for custom logger implementations.
+- middleware.WrapResponseWriter: minor fix
+- middleware.Recoverer: a bit prettier
+- History of changes: see https://github.com/go-chi/chi/compare/v4.0.4...v4.1.0
+
+## v4.0.4 (2020-03-24)
+
+- middleware.Recoverer: new pretty stack trace printing (https://github.com/go-chi/chi/pull/496)
+- a few minor improvements and fixes
+- History of changes: see https://github.com/go-chi/chi/compare/v4.0.3...v4.0.4
+
+
+## v4.0.3 (2020-01-09)
+
+- core: fix regexp routing to include default value when param is not matched
+- middleware: rewrite of middleware.Compress
+- middleware: suppress http.ErrAbortHandler in middleware.Recoverer
+- History of changes: see https://github.com/go-chi/chi/compare/v4.0.2...v4.0.3
+
+
+## v4.0.2 (2019-02-26)
+
+- Minor fixes
+- History of changes: see https://github.com/go-chi/chi/compare/v4.0.1...v4.0.2
+
+
+## v4.0.1 (2019-01-21)
+
+- Fixes issue with compress middleware: #382 #385
+- History of changes: see https://github.com/go-chi/chi/compare/v4.0.0...v4.0.1
+
+
+## v4.0.0 (2019-01-10)
+
+- chi v4 requires Go 1.10.3+ (or Go 1.9.7+) - we have deprecated support for Go 1.7 and 1.8
+- router: respond with 404 on router with no routes (#362)
+- router: additional check to ensure wildcard is at the end of a url pattern (#333)
+- middleware: deprecate use of http.CloseNotifier (#347)
+- middleware: fix RedirectSlashes to include query params on redirect (#334)
+- History of changes: see https://github.com/go-chi/chi/compare/v3.3.4...v4.0.0
+
+
+## v3.3.4 (2019-01-07)
+
+- Minor middleware improvements. No changes to core library/router. Moving v3 into its
+- own branch as a version of chi for Go 1.7, 1.8, 1.9, 1.10, 1.11
+- History of changes: see https://github.com/go-chi/chi/compare/v3.3.3...v3.3.4
+
+
+## v3.3.3 (2018-08-27)
+
+- Minor release
+- See https://github.com/go-chi/chi/compare/v3.3.2...v3.3.3
+
+
+## v3.3.2 (2017-12-22)
+
+- Support to route trailing slashes on mounted sub-routers (#281)
+- middleware: new `ContentCharset` to check matching charsets. Thank you
+  @csucu for your community contribution!
+
+
+## v3.3.1 (2017-11-20)
+
+- middleware: new `AllowContentType` handler for explicit whitelist of accepted request Content-Types
+- middleware: new `SetHeader` handler for short-hand middleware to set a response header key/value
+- Minor bug fixes
+
+
+## v3.3.0 (2017-10-10)
+
+- New chi.RegisterMethod(method) to add support for custom HTTP methods, see _examples/custom-method for usage
+- Deprecated LINK and UNLINK methods from the default list, please use `chi.RegisterMethod("LINK")` and `chi.RegisterMethod("UNLINK")` in an `init()` function
+
+
+## v3.2.1 (2017-08-31)
+
+- Add new `Match(rctx *Context, method, path string) bool` method to `Routes` interface
+  and `Mux`. Match searches the mux's routing tree for a handler that matches the method/path
+- Add new `RouteMethod` to `*Context`
+- Add new `Routes` pointer to `*Context`
+- Add new `middleware.GetHead` to route missing HEAD requests to GET handler
+- Updated benchmarks (see README)
+
+
+## v3.1.5 (2017-08-02)
+
+- Setup golint and go vet for the project
+- As per golint, we've redefined `func ServerBaseContext(h http.Handler, baseCtx context.Context) http.Handler`
+  to `func ServerBaseContext(baseCtx context.Context, h http.Handler) http.Handler`
+
+
+## v3.1.0 (2017-07-10)
+
+- Fix a few minor issues after v3 release
+- Move `docgen` sub-pkg to https://github.com/go-chi/docgen
+- Move `render` sub-pkg to https://github.com/go-chi/render
+- Add new `URLFormat` handler to chi/middleware sub-pkg to make working with url mime 
+  suffixes easier, ie. parsing `/articles/1.json` and `/articles/1.xml`. See comments in
+  https://github.com/go-chi/chi/blob/master/middleware/url_format.go for example usage.
+
+
+## v3.0.0 (2017-06-21)
+
+- Major update to chi library with many exciting updates, but also some *breaking changes*
+- URL parameter syntax changed from `/:id` to `/{id}` for even more flexible routing, such as
+  `/articles/{month}-{day}-{year}-{slug}`, `/articles/{id}`, and `/articles/{id}.{ext}` on the
+  same router
+- Support for regexp for routing patterns, in the form of `/{paramKey:regExp}` for example:
+  `r.Get("/articles/{name:[a-z]+}", h)` and `chi.URLParam(r, "name")`
+- Add `Method` and `MethodFunc` to `chi.Router` to allow routing definitions such as
+  `r.Method("GET", "/", h)` which provides a cleaner interface for custom handlers like
+  in `_examples/custom-handler`
+- Deprecating `mux#FileServer` helper function. Instead, we encourage users to create their
+  own using file handler with the stdlib, see `_examples/fileserver` for an example
+- Add support for LINK/UNLINK http methods via `r.Method()` and `r.MethodFunc()`
+- Moved the chi project to its own organization, to allow chi-related community packages to
+  be easily discovered and supported, at: https://github.com/go-chi
+- *NOTE:* please update your import paths to `"github.com/go-chi/chi"`
+- *NOTE:* chi v2 is still available at https://github.com/go-chi/chi/tree/v2
+
+
+## v2.1.0 (2017-03-30)
+
+- Minor improvements and update to the chi core library
+- Introduced a brand new `chi/render` sub-package to complete the story of building
+  APIs to offer a pattern for managing well-defined request / response payloads. Please
+  check out the updated `_examples/rest` example for how it works.
+- Added `MethodNotAllowed(h http.HandlerFunc)` to chi.Router interface
+
+
+## v2.0.0 (2017-01-06)
+
+- After many months of v2 being in an RC state with many companies and users running it in
+  production, the inclusion of some improvements to the middlewares, we are very pleased to
+  announce v2.0.0 of chi.
+
+
+## v2.0.0-rc1 (2016-07-26)
+
+- Huge update! chi v2 is a large refactor targeting Go 1.7+. As of Go 1.7, the popular
+  community `"net/context"` package has been included in the standard library as `"context"` and
+  utilized by `"net/http"` and `http.Request` to managing deadlines, cancelation signals and other
+  request-scoped values. We're very excited about the new context addition and are proud to
+  introduce chi v2, a minimal and powerful routing package for building large HTTP services,
+  with zero external dependencies. Chi focuses on idiomatic design and encourages the use of 
+  stdlib HTTP handlers and middlewares.
+- chi v2 deprecates its `chi.Handler` interface and requires `http.Handler` or `http.HandlerFunc`
+- chi v2 stores URL routing parameters and patterns in the standard request context: `r.Context()`
+- chi v2 lower-level routing context is accessible by `chi.RouteContext(r.Context()) *chi.Context`,
+  which provides direct access to URL routing parameters, the routing path and the matching
+  routing patterns.
+- Users upgrading from chi v1 to v2, need to:
+  1. Update the old chi.Handler signature, `func(ctx context.Context, w http.ResponseWriter, r *http.Request)` to
+     the standard http.Handler: `func(w http.ResponseWriter, r *http.Request)`
+  2. Use `chi.URLParam(r *http.Request, paramKey string) string`
+     or `URLParamFromCtx(ctx context.Context, paramKey string) string` to access a url parameter value
+
+
+## v1.0.0 (2016-07-01)
+
+- Released chi v1 stable https://github.com/go-chi/chi/tree/v1.0.0 for Go 1.6 and older.
+
+
+## v0.9.0 (2016-03-31)
+
+- Reuse context objects via sync.Pool for zero-allocation routing [#33](https://github.com/go-chi/chi/pull/33)
+- BREAKING NOTE: due to subtle API changes, previously `chi.URLParams(ctx)["id"]` used to access url parameters
+  has changed to: `chi.URLParam(ctx, "id")`

--- a/vendor/github.com/go-chi/chi/v5/CONTRIBUTING.md
+++ b/vendor/github.com/go-chi/chi/v5/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+## Prerequisites
+
+1. [Install Go][go-install].
+2. Download the sources and switch the working directory:
+
+    ```bash
+    go get -u -d github.com/go-chi/chi
+    cd $GOPATH/src/github.com/go-chi/chi
+    ```
+
+## Submitting a Pull Request
+
+A typical workflow is:
+
+1. [Fork the repository.][fork]
+2. [Create a topic branch.][branch]
+3. Add tests for your change.
+4. Run `go test`. If your tests pass, return to the step 3.
+5. Implement the change and ensure the steps from the previous step pass.
+6. Run `goimports -w .`, to ensure the new code conforms to Go formatting guideline.
+7. [Add, commit and push your changes.][git-help]
+8. [Submit a pull request.][pull-req]
+
+[go-install]: https://golang.org/doc/install
+[fork]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo
+[branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches 
+[git-help]: https://docs.github.com/en
+[pull-req]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests
+

--- a/vendor/github.com/go-chi/chi/v5/LICENSE
+++ b/vendor/github.com/go-chi/chi/v5/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2015-present Peter Kieltyka (https://github.com/pkieltyka), Google Inc.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/go-chi/chi/v5/Makefile
+++ b/vendor/github.com/go-chi/chi/v5/Makefile
@@ -1,0 +1,22 @@
+.PHONY: all
+all:
+	@echo "**********************************************************"
+	@echo "**                    chi build tool                    **"
+	@echo "**********************************************************"
+
+
+.PHONY: test
+test:
+	go clean -testcache && $(MAKE) test-router && $(MAKE) test-middleware
+
+.PHONY: test-router
+test-router:
+	go test -race -v .
+
+.PHONY: test-middleware
+test-middleware:
+	go test -race -v ./middleware
+
+.PHONY: docs
+docs:
+	npx docsify-cli serve ./docs

--- a/vendor/github.com/go-chi/chi/v5/README.md
+++ b/vendor/github.com/go-chi/chi/v5/README.md
@@ -1,0 +1,505 @@
+# <img alt="chi" src="https://cdn.rawgit.com/go-chi/chi/master/_examples/chi.svg" width="220" />
+
+
+[![GoDoc Widget]][GoDoc]
+
+`chi` is a lightweight, idiomatic and composable router for building Go HTTP services. It's
+especially good at helping you write large REST API services that are kept maintainable as your
+project grows and changes. `chi` is built on the new `context` package introduced in Go 1.7 to
+handle signaling, cancelation and request-scoped values across a handler chain.
+
+The focus of the project has been to seek out an elegant and comfortable design for writing
+REST API servers, written during the development of the Pressly API service that powers our
+public API service, which in turn powers all of our client-side applications.
+
+The key considerations of chi's design are: project structure, maintainability, standard http
+handlers (stdlib-only), developer productivity, and deconstructing a large system into many small
+parts. The core router `github.com/go-chi/chi` is quite small (less than 1000 LOC), but we've also
+included some useful/optional subpackages: [middleware](/middleware), [render](https://github.com/go-chi/render)
+and [docgen](https://github.com/go-chi/docgen). We hope you enjoy it too!
+
+## Install
+
+```sh
+go get -u github.com/go-chi/chi/v5
+```
+
+
+## Features
+
+* **Lightweight** - cloc'd in ~1000 LOC for the chi router
+* **Fast** - yes, see [benchmarks](#benchmarks)
+* **100% compatible with net/http** - use any http or middleware pkg in the ecosystem that is also compatible with `net/http`
+* **Designed for modular/composable APIs** - middlewares, inline middlewares, route groups and sub-router mounting
+* **Context control** - built on new `context` package, providing value chaining, cancellations and timeouts
+* **Robust** - in production at Pressly, Cloudflare, Heroku, 99Designs, and many others (see [discussion](https://github.com/go-chi/chi/issues/91))
+* **Doc generation** - `docgen` auto-generates routing documentation from your source to JSON or Markdown
+* **Go.mod support** - as of v5, go.mod support (see [CHANGELOG](https://github.com/go-chi/chi/blob/master/CHANGELOG.md))
+* **No external dependencies** - plain ol' Go stdlib + net/http
+
+
+## Examples
+
+See [_examples/](https://github.com/go-chi/chi/blob/master/_examples/) for a variety of examples.
+
+
+**As easy as:**
+
+```go
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+func main() {
+	r := chi.NewRouter()
+	r.Use(middleware.Logger)
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("welcome"))
+	})
+	http.ListenAndServe(":3000", r)
+}
+```
+
+**REST Preview:**
+
+Here is a little preview of what routing looks like with chi. Also take a look at the generated routing docs
+in JSON ([routes.json](https://github.com/go-chi/chi/blob/master/_examples/rest/routes.json)) and in
+Markdown ([routes.md](https://github.com/go-chi/chi/blob/master/_examples/rest/routes.md)).
+
+I highly recommend reading the source of the [examples](https://github.com/go-chi/chi/blob/master/_examples/) listed
+above, they will show you all the features of chi and serve as a good form of documentation.
+
+```go
+import (
+  //...
+  "context"
+  "github.com/go-chi/chi/v5"
+  "github.com/go-chi/chi/v5/middleware"
+)
+
+func main() {
+  r := chi.NewRouter()
+
+  // A good base middleware stack
+  r.Use(middleware.RequestID)
+  r.Use(middleware.RealIP)
+  r.Use(middleware.Logger)
+  r.Use(middleware.Recoverer)
+
+  // Set a timeout value on the request context (ctx), that will signal
+  // through ctx.Done() that the request has timed out and further
+  // processing should be stopped.
+  r.Use(middleware.Timeout(60 * time.Second))
+
+  r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+    w.Write([]byte("hi"))
+  })
+
+  // RESTy routes for "articles" resource
+  r.Route("/articles", func(r chi.Router) {
+    r.With(paginate).Get("/", listArticles)                           // GET /articles
+    r.With(paginate).Get("/{month}-{day}-{year}", listArticlesByDate) // GET /articles/01-16-2017
+
+    r.Post("/", createArticle)                                        // POST /articles
+    r.Get("/search", searchArticles)                                  // GET /articles/search
+
+    // Regexp url parameters:
+    r.Get("/{articleSlug:[a-z-]+}", getArticleBySlug)                // GET /articles/home-is-toronto
+
+    // Subrouters:
+    r.Route("/{articleID}", func(r chi.Router) {
+      r.Use(ArticleCtx)
+      r.Get("/", getArticle)                                          // GET /articles/123
+      r.Put("/", updateArticle)                                       // PUT /articles/123
+      r.Delete("/", deleteArticle)                                    // DELETE /articles/123
+    })
+  })
+
+  // Mount the admin sub-router
+  r.Mount("/admin", adminRouter())
+
+  http.ListenAndServe(":3333", r)
+}
+
+func ArticleCtx(next http.Handler) http.Handler {
+  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    articleID := chi.URLParam(r, "articleID")
+    article, err := dbGetArticle(articleID)
+    if err != nil {
+      http.Error(w, http.StatusText(404), 404)
+      return
+    }
+    ctx := context.WithValue(r.Context(), "article", article)
+    next.ServeHTTP(w, r.WithContext(ctx))
+  })
+}
+
+func getArticle(w http.ResponseWriter, r *http.Request) {
+  ctx := r.Context()
+  article, ok := ctx.Value("article").(*Article)
+  if !ok {
+    http.Error(w, http.StatusText(422), 422)
+    return
+  }
+  w.Write([]byte(fmt.Sprintf("title:%s", article.Title)))
+}
+
+// A completely separate router for administrator routes
+func adminRouter() http.Handler {
+  r := chi.NewRouter()
+  r.Use(AdminOnly)
+  r.Get("/", adminIndex)
+  r.Get("/accounts", adminListAccounts)
+  return r
+}
+
+func AdminOnly(next http.Handler) http.Handler {
+  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    ctx := r.Context()
+    perm, ok := ctx.Value("acl.permission").(YourPermissionType)
+    if !ok || !perm.IsAdmin() {
+      http.Error(w, http.StatusText(403), 403)
+      return
+    }
+    next.ServeHTTP(w, r)
+  })
+}
+```
+
+
+## Router interface
+
+chi's router is based on a kind of [Patricia Radix trie](https://en.wikipedia.org/wiki/Radix_tree).
+The router is fully compatible with `net/http`.
+
+Built on top of the tree is the `Router` interface:
+
+```go
+// Router consisting of the core routing methods used by chi's Mux,
+// using only the standard net/http.
+type Router interface {
+	http.Handler
+	Routes
+
+	// Use appends one or more middlewares onto the Router stack.
+	Use(middlewares ...func(http.Handler) http.Handler)
+
+	// With adds inline middlewares for an endpoint handler.
+	With(middlewares ...func(http.Handler) http.Handler) Router
+
+	// Group adds a new inline-Router along the current routing
+	// path, with a fresh middleware stack for the inline-Router.
+	Group(fn func(r Router)) Router
+
+	// Route mounts a sub-Router along a `pattern` string.
+	Route(pattern string, fn func(r Router)) Router
+
+	// Mount attaches another http.Handler along ./pattern/*
+	Mount(pattern string, h http.Handler)
+
+	// Handle and HandleFunc adds routes for `pattern` that matches
+	// all HTTP methods.
+	Handle(pattern string, h http.Handler)
+	HandleFunc(pattern string, h http.HandlerFunc)
+
+	// Method and MethodFunc adds routes for `pattern` that matches
+	// the `method` HTTP method.
+	Method(method, pattern string, h http.Handler)
+	MethodFunc(method, pattern string, h http.HandlerFunc)
+
+	// HTTP-method routing along `pattern`
+	Connect(pattern string, h http.HandlerFunc)
+	Delete(pattern string, h http.HandlerFunc)
+	Get(pattern string, h http.HandlerFunc)
+	Head(pattern string, h http.HandlerFunc)
+	Options(pattern string, h http.HandlerFunc)
+	Patch(pattern string, h http.HandlerFunc)
+	Post(pattern string, h http.HandlerFunc)
+	Put(pattern string, h http.HandlerFunc)
+	Trace(pattern string, h http.HandlerFunc)
+
+	// NotFound defines a handler to respond whenever a route could
+	// not be found.
+	NotFound(h http.HandlerFunc)
+
+	// MethodNotAllowed defines a handler to respond whenever a method is
+	// not allowed.
+	MethodNotAllowed(h http.HandlerFunc)
+}
+
+// Routes interface adds two methods for router traversal, which is also
+// used by the github.com/go-chi/docgen package to generate documentation for Routers.
+type Routes interface {
+	// Routes returns the routing tree in an easily traversable structure.
+	Routes() []Route
+
+	// Middlewares returns the list of middlewares in use by the router.
+	Middlewares() Middlewares
+
+	// Match searches the routing tree for a handler that matches
+	// the method/path - similar to routing a http request, but without
+	// executing the handler thereafter.
+	Match(rctx *Context, method, path string) bool
+}
+```
+
+Each routing method accepts a URL `pattern` and chain of `handlers`. The URL pattern
+supports named params (ie. `/users/{userID}`) and wildcards (ie. `/admin/*`). URL parameters
+can be fetched at runtime by calling `chi.URLParam(r, "userID")` for named parameters
+and `chi.URLParam(r, "*")` for a wildcard parameter.
+
+
+### Middleware handlers
+
+chi's middlewares are just stdlib net/http middleware handlers. There is nothing special
+about them, which means the router and all the tooling is designed to be compatible and
+friendly with any middleware in the community. This offers much better extensibility and reuse
+of packages and is at the heart of chi's purpose.
+
+Here is an example of a standard net/http middleware where we assign a context key `"user"`
+the value of `"123"`. This middleware sets a hypothetical user identifier on the request
+context and calls the next handler in the chain.
+
+```go
+// HTTP middleware setting a value on the request context
+func MyMiddleware(next http.Handler) http.Handler {
+  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    // create new context from `r` request context, and assign key `"user"`
+    // to value of `"123"`
+    ctx := context.WithValue(r.Context(), "user", "123")
+
+    // call the next handler in the chain, passing the response writer and
+    // the updated request object with the new context value.
+    //
+    // note: context.Context values are nested, so any previously set
+    // values will be accessible as well, and the new `"user"` key
+    // will be accessible from this point forward.
+    next.ServeHTTP(w, r.WithContext(ctx))
+  })
+}
+```
+
+
+### Request handlers
+
+chi uses standard net/http request handlers. This little snippet is an example of a http.Handler
+func that reads a user identifier from the request context - hypothetically, identifying
+the user sending an authenticated request, validated+set by a previous middleware handler.
+
+```go
+// HTTP handler accessing data from the request context.
+func MyRequestHandler(w http.ResponseWriter, r *http.Request) {
+  // here we read from the request context and fetch out `"user"` key set in
+  // the MyMiddleware example above.
+  user := r.Context().Value("user").(string)
+
+  // respond to the client
+  w.Write([]byte(fmt.Sprintf("hi %s", user)))
+}
+```
+
+
+### URL parameters
+
+chi's router parses and stores URL parameters right onto the request context. Here is
+an example of how to access URL params in your net/http handlers. And of course, middlewares
+are able to access the same information.
+
+```go
+// HTTP handler accessing the url routing parameters.
+func MyRequestHandler(w http.ResponseWriter, r *http.Request) {
+  // fetch the url parameter `"userID"` from the request of a matching
+  // routing pattern. An example routing pattern could be: /users/{userID}
+  userID := chi.URLParam(r, "userID")
+
+  // fetch `"key"` from the request context
+  ctx := r.Context()
+  key := ctx.Value("key").(string)
+
+  // respond to the client
+  w.Write([]byte(fmt.Sprintf("hi %v, %v", userID, key)))
+}
+```
+
+
+## Middlewares
+
+chi comes equipped with an optional `middleware` package, providing a suite of standard
+`net/http` middlewares. Please note, any middleware in the ecosystem that is also compatible
+with `net/http` can be used with chi's mux.
+
+### Core middlewares
+
+----------------------------------------------------------------------------------------------------
+| chi/middleware Handler | description                                                             |
+| :--------------------- | :---------------------------------------------------------------------- |
+| [AllowContentEncoding] | Enforces a whitelist of request Content-Encoding headers                |
+| [AllowContentType]     | Explicit whitelist of accepted request Content-Types                    |
+| [BasicAuth]            | Basic HTTP authentication                                               |
+| [Compress]             | Gzip compression for clients that accept compressed responses           |
+| [ContentCharset]       | Ensure charset for Content-Type request headers                         |
+| [CleanPath]            | Clean double slashes from request path                                  |
+| [GetHead]              | Automatically route undefined HEAD requests to GET handlers             |
+| [Heartbeat]            | Monitoring endpoint to check the servers pulse                          |
+| [Logger]               | Logs the start and end of each request with the elapsed processing time |
+| [NoCache]              | Sets response headers to prevent clients from caching                   |
+| [Profiler]             | Easily attach net/http/pprof to your routers                            |
+| [RealIP]               | Sets a http.Request's RemoteAddr to either X-Real-IP or X-Forwarded-For |
+| [Recoverer]            | Gracefully absorb panics and prints the stack trace                     |
+| [RequestID]            | Injects a request ID into the context of each request                   |
+| [RedirectSlashes]      | Redirect slashes on routing paths                                       |
+| [RouteHeaders]         | Route handling for request headers                                      |
+| [SetHeader]            | Short-hand middleware to set a response header key/value                |
+| [StripSlashes]         | Strip slashes on routing paths                                          |
+| [Sunset]               | Sunset set Deprecation/Sunset header to response                        |
+| [Throttle]             | Puts a ceiling on the number of concurrent requests                     |
+| [Timeout]              | Signals to the request context when the timeout deadline is reached     |
+| [URLFormat]            | Parse extension from url and put it on request context                  |
+| [WithValue]            | Short-hand middleware to set a key/value on the request context         |
+----------------------------------------------------------------------------------------------------
+
+[AllowContentEncoding]: https://pkg.go.dev/github.com/go-chi/chi/middleware#AllowContentEncoding
+[AllowContentType]: https://pkg.go.dev/github.com/go-chi/chi/middleware#AllowContentType
+[BasicAuth]: https://pkg.go.dev/github.com/go-chi/chi/middleware#BasicAuth
+[Compress]: https://pkg.go.dev/github.com/go-chi/chi/middleware#Compress
+[ContentCharset]: https://pkg.go.dev/github.com/go-chi/chi/middleware#ContentCharset
+[CleanPath]: https://pkg.go.dev/github.com/go-chi/chi/middleware#CleanPath
+[GetHead]: https://pkg.go.dev/github.com/go-chi/chi/middleware#GetHead
+[GetReqID]: https://pkg.go.dev/github.com/go-chi/chi/middleware#GetReqID
+[Heartbeat]: https://pkg.go.dev/github.com/go-chi/chi/middleware#Heartbeat
+[Logger]: https://pkg.go.dev/github.com/go-chi/chi/middleware#Logger
+[NoCache]: https://pkg.go.dev/github.com/go-chi/chi/middleware#NoCache
+[Profiler]: https://pkg.go.dev/github.com/go-chi/chi/middleware#Profiler
+[RealIP]: https://pkg.go.dev/github.com/go-chi/chi/middleware#RealIP
+[Recoverer]: https://pkg.go.dev/github.com/go-chi/chi/middleware#Recoverer
+[RedirectSlashes]: https://pkg.go.dev/github.com/go-chi/chi/middleware#RedirectSlashes
+[RequestLogger]: https://pkg.go.dev/github.com/go-chi/chi/middleware#RequestLogger
+[RequestID]: https://pkg.go.dev/github.com/go-chi/chi/middleware#RequestID
+[RouteHeaders]: https://pkg.go.dev/github.com/go-chi/chi/middleware#RouteHeaders
+[SetHeader]: https://pkg.go.dev/github.com/go-chi/chi/middleware#SetHeader
+[StripSlashes]: https://pkg.go.dev/github.com/go-chi/chi/middleware#StripSlashes
+[Sunset]: https://pkg.go.dev/github.com/go-chi/chi/v5/middleware#Sunset
+[Throttle]: https://pkg.go.dev/github.com/go-chi/chi/middleware#Throttle
+[ThrottleBacklog]: https://pkg.go.dev/github.com/go-chi/chi/middleware#ThrottleBacklog
+[ThrottleWithOpts]: https://pkg.go.dev/github.com/go-chi/chi/middleware#ThrottleWithOpts
+[Timeout]: https://pkg.go.dev/github.com/go-chi/chi/middleware#Timeout
+[URLFormat]: https://pkg.go.dev/github.com/go-chi/chi/middleware#URLFormat
+[WithLogEntry]: https://pkg.go.dev/github.com/go-chi/chi/middleware#WithLogEntry
+[WithValue]: https://pkg.go.dev/github.com/go-chi/chi/middleware#WithValue
+[Compressor]: https://pkg.go.dev/github.com/go-chi/chi/middleware#Compressor
+[DefaultLogFormatter]: https://pkg.go.dev/github.com/go-chi/chi/middleware#DefaultLogFormatter
+[EncoderFunc]: https://pkg.go.dev/github.com/go-chi/chi/middleware#EncoderFunc
+[HeaderRoute]: https://pkg.go.dev/github.com/go-chi/chi/middleware#HeaderRoute
+[HeaderRouter]: https://pkg.go.dev/github.com/go-chi/chi/middleware#HeaderRouter
+[LogEntry]: https://pkg.go.dev/github.com/go-chi/chi/middleware#LogEntry
+[LogFormatter]: https://pkg.go.dev/github.com/go-chi/chi/middleware#LogFormatter
+[LoggerInterface]: https://pkg.go.dev/github.com/go-chi/chi/middleware#LoggerInterface
+[ThrottleOpts]: https://pkg.go.dev/github.com/go-chi/chi/middleware#ThrottleOpts
+[WrapResponseWriter]: https://pkg.go.dev/github.com/go-chi/chi/middleware#WrapResponseWriter
+
+### Extra middlewares & packages
+
+Please see https://github.com/go-chi for additional packages.
+
+--------------------------------------------------------------------------------------------------------------------
+| package                                            | description                                                 |
+|:---------------------------------------------------|:-------------------------------------------------------------
+| [cors](https://github.com/go-chi/cors)             | Cross-origin resource sharing (CORS)                        |
+| [docgen](https://github.com/go-chi/docgen)         | Print chi.Router routes at runtime                          |
+| [jwtauth](https://github.com/go-chi/jwtauth)       | JWT authentication                                          |
+| [hostrouter](https://github.com/go-chi/hostrouter) | Domain/host based request routing                           |
+| [httplog](https://github.com/go-chi/httplog)       | Small but powerful structured HTTP request logging          |
+| [httprate](https://github.com/go-chi/httprate)     | HTTP request rate limiter                                   |
+| [httptracer](https://github.com/go-chi/httptracer) | HTTP request performance tracing library                    |
+| [httpvcr](https://github.com/go-chi/httpvcr)       | Write deterministic tests for external sources              |
+| [stampede](https://github.com/go-chi/stampede)     | HTTP request coalescer                                      |
+--------------------------------------------------------------------------------------------------------------------
+
+
+## context?
+
+`context` is a tiny pkg that provides simple interface to signal context across call stacks
+and goroutines. It was originally written by [Sameer Ajmani](https://github.com/Sajmani)
+and is available in stdlib since go1.7.
+
+Learn more at https://blog.golang.org/context
+
+and..
+* Docs: https://golang.org/pkg/context
+* Source: https://github.com/golang/go/tree/master/src/context
+
+
+## Benchmarks
+
+The benchmark suite: https://github.com/pkieltyka/go-http-routing-benchmark
+
+Results as of Nov 29, 2020 with Go 1.15.5 on Linux AMD 3950x
+
+```shell
+BenchmarkChi_Param          	3075895	        384 ns/op	      400 B/op      2 allocs/op
+BenchmarkChi_Param5         	2116603	        566 ns/op	      400 B/op      2 allocs/op
+BenchmarkChi_Param20        	 964117	       1227 ns/op	      400 B/op      2 allocs/op
+BenchmarkChi_ParamWrite     	2863413	        420 ns/op	      400 B/op      2 allocs/op
+BenchmarkChi_GithubStatic   	3045488	        395 ns/op	      400 B/op      2 allocs/op
+BenchmarkChi_GithubParam    	2204115	        540 ns/op	      400 B/op      2 allocs/op
+BenchmarkChi_GithubAll      	  10000	     113811 ns/op	    81203 B/op    406 allocs/op
+BenchmarkChi_GPlusStatic    	3337485	        359 ns/op	      400 B/op      2 allocs/op
+BenchmarkChi_GPlusParam     	2825853	        423 ns/op	      400 B/op      2 allocs/op
+BenchmarkChi_GPlus2Params   	2471697	        483 ns/op	      400 B/op      2 allocs/op
+BenchmarkChi_GPlusAll       	 194220	       5950 ns/op	     5200 B/op     26 allocs/op
+BenchmarkChi_ParseStatic    	3365324	        356 ns/op	      400 B/op      2 allocs/op
+BenchmarkChi_ParseParam     	2976614	        404 ns/op	      400 B/op      2 allocs/op
+BenchmarkChi_Parse2Params   	2638084	        439 ns/op	      400 B/op      2 allocs/op
+BenchmarkChi_ParseAll       	 109567	      11295 ns/op	    10400 B/op     52 allocs/op
+BenchmarkChi_StaticAll      	  16846	      71308 ns/op	    62802 B/op    314 allocs/op
+```
+
+Comparison with other routers: https://gist.github.com/pkieltyka/123032f12052520aaccab752bd3e78cc
+
+NOTE: the allocs in the benchmark above are from the calls to http.Request's
+`WithContext(context.Context)` method that clones the http.Request, sets the `Context()`
+on the duplicated (alloc'd) request and returns it the new request object. This is just
+how setting context on a request in Go works.
+
+
+## Credits
+
+* Carl Jackson for https://github.com/zenazn/goji
+  * Parts of chi's thinking comes from goji, and chi's middleware package
+    sources from [goji](https://github.com/zenazn/goji/tree/master/web/middleware).
+  * Please see goji's [LICENSE](https://github.com/zenazn/goji/blob/master/LICENSE) (MIT)
+* Armon Dadgar for https://github.com/armon/go-radix
+* Contributions: [@VojtechVitek](https://github.com/VojtechVitek)
+
+We'll be more than happy to see [your contributions](./CONTRIBUTING.md)!
+
+
+## Beyond REST
+
+chi is just a http router that lets you decompose request handling into many smaller layers.
+Many companies use chi to write REST services for their public APIs. But, REST is just a convention
+for managing state via HTTP, and there's a lot of other pieces required to write a complete client-server
+system or network of microservices.
+
+Looking beyond REST, I also recommend some newer works in the field:
+* [webrpc](https://github.com/webrpc/webrpc) - Web-focused RPC client+server framework with code-gen
+* [gRPC](https://github.com/grpc/grpc-go) - Google's RPC framework via protobufs
+* [graphql](https://github.com/99designs/gqlgen) - Declarative query language
+* [NATS](https://nats.io) - lightweight pub-sub
+
+
+## License
+
+Copyright (c) 2015-present [Peter Kieltyka](https://github.com/pkieltyka)
+
+Licensed under [MIT License](./LICENSE)
+
+[GoDoc]: https://pkg.go.dev/github.com/go-chi/chi/v5
+[GoDoc Widget]: https://godoc.org/github.com/go-chi/chi?status.svg
+[Travis]: https://travis-ci.org/go-chi/chi
+[Travis Widget]: https://travis-ci.org/go-chi/chi.svg?branch=master

--- a/vendor/github.com/go-chi/chi/v5/SECURITY.md
+++ b/vendor/github.com/go-chi/chi/v5/SECURITY.md
@@ -1,0 +1,5 @@
+# Reporting Security Issues
+
+We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/go-chi/chi/security/advisories/new) tab.

--- a/vendor/github.com/go-chi/chi/v5/chain.go
+++ b/vendor/github.com/go-chi/chi/v5/chain.go
@@ -1,0 +1,49 @@
+package chi
+
+import "net/http"
+
+// Chain returns a Middlewares type from a slice of middleware handlers.
+func Chain(middlewares ...func(http.Handler) http.Handler) Middlewares {
+	return Middlewares(middlewares)
+}
+
+// Handler builds and returns a http.Handler from the chain of middlewares,
+// with `h http.Handler` as the final handler.
+func (mws Middlewares) Handler(h http.Handler) http.Handler {
+	return &ChainHandler{h, chain(mws, h), mws}
+}
+
+// HandlerFunc builds and returns a http.Handler from the chain of middlewares,
+// with `h http.Handler` as the final handler.
+func (mws Middlewares) HandlerFunc(h http.HandlerFunc) http.Handler {
+	return &ChainHandler{h, chain(mws, h), mws}
+}
+
+// ChainHandler is a http.Handler with support for handler composition and
+// execution.
+type ChainHandler struct {
+	Endpoint    http.Handler
+	chain       http.Handler
+	Middlewares Middlewares
+}
+
+func (c *ChainHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	c.chain.ServeHTTP(w, r)
+}
+
+// chain builds a http.Handler composed of an inline middleware stack and endpoint
+// handler in the order they are passed.
+func chain(middlewares []func(http.Handler) http.Handler, endpoint http.Handler) http.Handler {
+	// Return ahead of time if there aren't any middlewares for the chain
+	if len(middlewares) == 0 {
+		return endpoint
+	}
+
+	// Wrap the end handler with the middleware chain
+	h := middlewares[len(middlewares)-1](endpoint)
+	for i := len(middlewares) - 2; i >= 0; i-- {
+		h = middlewares[i](h)
+	}
+
+	return h
+}

--- a/vendor/github.com/go-chi/chi/v5/chi.go
+++ b/vendor/github.com/go-chi/chi/v5/chi.go
@@ -1,0 +1,137 @@
+// Package chi is a small, idiomatic and composable router for building HTTP services.
+//
+// chi supports the four most recent major versions of Go.
+//
+// Example:
+//
+//	package main
+//
+//	import (
+//		"net/http"
+//
+//		"github.com/go-chi/chi/v5"
+//		"github.com/go-chi/chi/v5/middleware"
+//	)
+//
+//	func main() {
+//		r := chi.NewRouter()
+//		r.Use(middleware.Logger)
+//		r.Use(middleware.Recoverer)
+//
+//		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+//			w.Write([]byte("root."))
+//		})
+//
+//		http.ListenAndServe(":3333", r)
+//	}
+//
+// See github.com/go-chi/chi/_examples/ for more in-depth examples.
+//
+// URL patterns allow for easy matching of path components in HTTP
+// requests. The matching components can then be accessed using
+// chi.URLParam(). All patterns must begin with a slash.
+//
+// A simple named placeholder {name} matches any sequence of characters
+// up to the next / or the end of the URL. Trailing slashes on paths must
+// be handled explicitly.
+//
+// A placeholder with a name followed by a colon allows a regular
+// expression match, for example {number:\\d+}. The regular expression
+// syntax is Go's normal regexp RE2 syntax, except that / will never be
+// matched. An anonymous regexp pattern is allowed, using an empty string
+// before the colon in the placeholder, such as {:\\d+}
+//
+// The special placeholder of asterisk matches the rest of the requested
+// URL. Any trailing characters in the pattern are ignored. This is the only
+// placeholder which will match / characters.
+//
+// Examples:
+//
+//	"/user/{name}" matches "/user/jsmith" but not "/user/jsmith/info" or "/user/jsmith/"
+//	"/user/{name}/info" matches "/user/jsmith/info"
+//	"/page/*" matches "/page/intro/latest"
+//	"/page/{other}/latest" also matches "/page/intro/latest"
+//	"/date/{yyyy:\\d\\d\\d\\d}/{mm:\\d\\d}/{dd:\\d\\d}" matches "/date/2017/04/01"
+package chi
+
+import "net/http"
+
+// NewRouter returns a new Mux object that implements the Router interface.
+func NewRouter() *Mux {
+	return NewMux()
+}
+
+// Router consisting of the core routing methods used by chi's Mux,
+// using only the standard net/http.
+type Router interface {
+	http.Handler
+	Routes
+
+	// Use appends one or more middlewares onto the Router stack.
+	Use(middlewares ...func(http.Handler) http.Handler)
+
+	// With adds inline middlewares for an endpoint handler.
+	With(middlewares ...func(http.Handler) http.Handler) Router
+
+	// Group adds a new inline-Router along the current routing
+	// path, with a fresh middleware stack for the inline-Router.
+	Group(fn func(r Router)) Router
+
+	// Route mounts a sub-Router along a `pattern`` string.
+	Route(pattern string, fn func(r Router)) Router
+
+	// Mount attaches another http.Handler along ./pattern/*
+	Mount(pattern string, h http.Handler)
+
+	// Handle and HandleFunc adds routes for `pattern` that matches
+	// all HTTP methods.
+	Handle(pattern string, h http.Handler)
+	HandleFunc(pattern string, h http.HandlerFunc)
+
+	// Method and MethodFunc adds routes for `pattern` that matches
+	// the `method` HTTP method.
+	Method(method, pattern string, h http.Handler)
+	MethodFunc(method, pattern string, h http.HandlerFunc)
+
+	// HTTP-method routing along `pattern`
+	Connect(pattern string, h http.HandlerFunc)
+	Delete(pattern string, h http.HandlerFunc)
+	Get(pattern string, h http.HandlerFunc)
+	Head(pattern string, h http.HandlerFunc)
+	Options(pattern string, h http.HandlerFunc)
+	Patch(pattern string, h http.HandlerFunc)
+	Post(pattern string, h http.HandlerFunc)
+	Put(pattern string, h http.HandlerFunc)
+	Trace(pattern string, h http.HandlerFunc)
+
+	// NotFound defines a handler to respond whenever a route could
+	// not be found.
+	NotFound(h http.HandlerFunc)
+
+	// MethodNotAllowed defines a handler to respond whenever a method is
+	// not allowed.
+	MethodNotAllowed(h http.HandlerFunc)
+}
+
+// Routes interface adds two methods for router traversal, which is also
+// used by the `docgen` subpackage to generation documentation for Routers.
+type Routes interface {
+	// Routes returns the routing tree in an easily traversable structure.
+	Routes() []Route
+
+	// Middlewares returns the list of middlewares in use by the router.
+	Middlewares() Middlewares
+
+	// Match searches the routing tree for a handler that matches
+	// the method/path - similar to routing a http request, but without
+	// executing the handler thereafter.
+	Match(rctx *Context, method, path string) bool
+
+	// Find searches the routing tree for the pattern that matches
+	// the method/path.
+	Find(rctx *Context, method, path string) string
+}
+
+// Middlewares type is a slice of standard middleware handlers with methods
+// to compose middleware chains and http.Handler's.
+type Middlewares []func(http.Handler) http.Handler

--- a/vendor/github.com/go-chi/chi/v5/context.go
+++ b/vendor/github.com/go-chi/chi/v5/context.go
@@ -1,0 +1,166 @@
+package chi
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+// URLParam returns the url parameter from a http.Request object.
+func URLParam(r *http.Request, key string) string {
+	if rctx := RouteContext(r.Context()); rctx != nil {
+		return rctx.URLParam(key)
+	}
+	return ""
+}
+
+// URLParamFromCtx returns the url parameter from a http.Request Context.
+func URLParamFromCtx(ctx context.Context, key string) string {
+	if rctx := RouteContext(ctx); rctx != nil {
+		return rctx.URLParam(key)
+	}
+	return ""
+}
+
+// RouteContext returns chi's routing Context object from a
+// http.Request Context.
+func RouteContext(ctx context.Context) *Context {
+	val, _ := ctx.Value(RouteCtxKey).(*Context)
+	return val
+}
+
+// NewRouteContext returns a new routing Context object.
+func NewRouteContext() *Context {
+	return &Context{}
+}
+
+var (
+	// RouteCtxKey is the context.Context key to store the request context.
+	RouteCtxKey = &contextKey{"RouteContext"}
+)
+
+// Context is the default routing context set on the root node of a
+// request context to track route patterns, URL parameters and
+// an optional routing path.
+type Context struct {
+	Routes Routes
+
+	// parentCtx is the parent of this one, for using Context as a
+	// context.Context directly. This is an optimization that saves
+	// 1 allocation.
+	parentCtx context.Context
+
+	// Routing path/method override used during the route search.
+	// See Mux#routeHTTP method.
+	RoutePath   string
+	RouteMethod string
+
+	// URLParams are the stack of routeParams captured during the
+	// routing lifecycle across a stack of sub-routers.
+	URLParams RouteParams
+
+	// Route parameters matched for the current sub-router. It is
+	// intentionally unexported so it can't be tampered.
+	routeParams RouteParams
+
+	// The endpoint routing pattern that matched the request URI path
+	// or `RoutePath` of the current sub-router. This value will update
+	// during the lifecycle of a request passing through a stack of
+	// sub-routers.
+	routePattern string
+
+	// Routing pattern stack throughout the lifecycle of the request,
+	// across all connected routers. It is a record of all matching
+	// patterns across a stack of sub-routers.
+	RoutePatterns []string
+
+	methodsAllowed   []methodTyp // allowed methods in case of a 405
+	methodNotAllowed bool
+}
+
+// Reset a routing context to its initial state.
+func (x *Context) Reset() {
+	x.Routes = nil
+	x.RoutePath = ""
+	x.RouteMethod = ""
+	x.RoutePatterns = x.RoutePatterns[:0]
+	x.URLParams.Keys = x.URLParams.Keys[:0]
+	x.URLParams.Values = x.URLParams.Values[:0]
+
+	x.routePattern = ""
+	x.routeParams.Keys = x.routeParams.Keys[:0]
+	x.routeParams.Values = x.routeParams.Values[:0]
+	x.methodNotAllowed = false
+	x.methodsAllowed = x.methodsAllowed[:0]
+	x.parentCtx = nil
+}
+
+// URLParam returns the corresponding URL parameter value from the request
+// routing context.
+func (x *Context) URLParam(key string) string {
+	for k := len(x.URLParams.Keys) - 1; k >= 0; k-- {
+		if x.URLParams.Keys[k] == key {
+			return x.URLParams.Values[k]
+		}
+	}
+	return ""
+}
+
+// RoutePattern builds the routing pattern string for the particular
+// request, at the particular point during routing. This means, the value
+// will change throughout the execution of a request in a router. That is
+// why it's advised to only use this value after calling the next handler.
+//
+// For example,
+//
+//	func Instrument(next http.Handler) http.Handler {
+//		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//			next.ServeHTTP(w, r)
+//			routePattern := chi.RouteContext(r.Context()).RoutePattern()
+//			measure(w, r, routePattern)
+//		})
+//	}
+func (x *Context) RoutePattern() string {
+	if x == nil {
+		return ""
+	}
+	routePattern := strings.Join(x.RoutePatterns, "")
+	routePattern = replaceWildcards(routePattern)
+	if routePattern != "/" {
+		routePattern = strings.TrimSuffix(routePattern, "//")
+		routePattern = strings.TrimSuffix(routePattern, "/")
+	}
+	return routePattern
+}
+
+// replaceWildcards takes a route pattern and replaces all occurrences of
+// "/*/" with "/". It iteratively runs until no wildcards remain to
+// correctly handle consecutive wildcards.
+func replaceWildcards(p string) string {
+	for strings.Contains(p, "/*/") {
+		p = strings.ReplaceAll(p, "/*/", "/")
+	}
+	return p
+}
+
+// RouteParams is a structure to track URL routing parameters efficiently.
+type RouteParams struct {
+	Keys, Values []string
+}
+
+// Add will append a URL parameter to the end of the route param
+func (s *RouteParams) Add(key, value string) {
+	s.Keys = append(s.Keys, key)
+	s.Values = append(s.Values, value)
+}
+
+// contextKey is a value for use with context.WithValue. It's used as
+// a pointer so it fits in an interface{} without allocation. This technique
+// for defining context keys was copied from Go 1.7's new use of context in net/http.
+type contextKey struct {
+	name string
+}
+
+func (k *contextKey) String() string {
+	return "chi context value " + k.name
+}

--- a/vendor/github.com/go-chi/chi/v5/mux.go
+++ b/vendor/github.com/go-chi/chi/v5/mux.go
@@ -1,0 +1,528 @@
+package chi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+var _ Router = &Mux{}
+
+// Mux is a simple HTTP route multiplexer that parses a request path,
+// records any URL params, and executes an end handler. It implements
+// the http.Handler interface and is friendly with the standard library.
+//
+// Mux is designed to be fast, minimal and offer a powerful API for building
+// modular and composable HTTP services with a large set of handlers. It's
+// particularly useful for writing large REST API services that break a handler
+// into many smaller parts composed of middlewares and end handlers.
+type Mux struct {
+	// The computed mux handler made of the chained middleware stack and
+	// the tree router
+	handler http.Handler
+
+	// The radix trie router
+	tree *node
+
+	// Custom method not allowed handler
+	methodNotAllowedHandler http.HandlerFunc
+
+	// A reference to the parent mux used by subrouters when mounting
+	// to a parent mux
+	parent *Mux
+
+	// Routing context pool
+	pool *sync.Pool
+
+	// Custom route not found handler
+	notFoundHandler http.HandlerFunc
+
+	// The middleware stack
+	middlewares []func(http.Handler) http.Handler
+
+	// Controls the behaviour of middleware chain generation when a mux
+	// is registered as an inline group inside another mux.
+	inline bool
+}
+
+// NewMux returns a newly initialized Mux object that implements the Router
+// interface.
+func NewMux() *Mux {
+	mux := &Mux{tree: &node{}, pool: &sync.Pool{}}
+	mux.pool.New = func() interface{} {
+		return NewRouteContext()
+	}
+	return mux
+}
+
+// ServeHTTP is the single method of the http.Handler interface that makes
+// Mux interoperable with the standard library. It uses a sync.Pool to get and
+// reuse routing contexts for each request.
+func (mx *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Ensure the mux has some routes defined on the mux
+	if mx.handler == nil {
+		mx.NotFoundHandler().ServeHTTP(w, r)
+		return
+	}
+
+	// Check if a routing context already exists from a parent router.
+	rctx, _ := r.Context().Value(RouteCtxKey).(*Context)
+	if rctx != nil {
+		mx.handler.ServeHTTP(w, r)
+		return
+	}
+
+	// Fetch a RouteContext object from the sync pool, and call the computed
+	// mx.handler that is comprised of mx.middlewares + mx.routeHTTP.
+	// Once the request is finished, reset the routing context and put it back
+	// into the pool for reuse from another request.
+	rctx = mx.pool.Get().(*Context)
+	rctx.Reset()
+	rctx.Routes = mx
+	rctx.parentCtx = r.Context()
+
+	// NOTE: r.WithContext() causes 2 allocations and context.WithValue() causes 1 allocation
+	r = r.WithContext(context.WithValue(r.Context(), RouteCtxKey, rctx))
+
+	// Serve the request and once its done, put the request context back in the sync pool
+	mx.handler.ServeHTTP(w, r)
+	mx.pool.Put(rctx)
+}
+
+// Use appends a middleware handler to the Mux middleware stack.
+//
+// The middleware stack for any Mux will execute before searching for a matching
+// route to a specific handler, which provides opportunity to respond early,
+// change the course of the request execution, or set request-scoped values for
+// the next http.Handler.
+func (mx *Mux) Use(middlewares ...func(http.Handler) http.Handler) {
+	if mx.handler != nil {
+		panic("chi: all middlewares must be defined before routes on a mux")
+	}
+	mx.middlewares = append(mx.middlewares, middlewares...)
+}
+
+// Handle adds the route `pattern` that matches any http method to
+// execute the `handler` http.Handler.
+func (mx *Mux) Handle(pattern string, handler http.Handler) {
+	if i := strings.IndexAny(pattern, " \t"); i >= 0 {
+		method, rest := pattern[:i], strings.TrimLeft(pattern[i+1:], " \t")
+		mx.Method(method, rest, handler)
+		return
+	}
+
+	mx.handle(mALL, pattern, handler)
+}
+
+// HandleFunc adds the route `pattern` that matches any http method to
+// execute the `handlerFn` http.HandlerFunc.
+func (mx *Mux) HandleFunc(pattern string, handlerFn http.HandlerFunc) {
+	mx.Handle(pattern, handlerFn)
+}
+
+// Method adds the route `pattern` that matches `method` http method to
+// execute the `handler` http.Handler.
+func (mx *Mux) Method(method, pattern string, handler http.Handler) {
+	m, ok := methodMap[strings.ToUpper(method)]
+	if !ok {
+		panic(fmt.Sprintf("chi: '%s' http method is not supported.", method))
+	}
+	mx.handle(m, pattern, handler)
+}
+
+// MethodFunc adds the route `pattern` that matches `method` http method to
+// execute the `handlerFn` http.HandlerFunc.
+func (mx *Mux) MethodFunc(method, pattern string, handlerFn http.HandlerFunc) {
+	mx.Method(method, pattern, handlerFn)
+}
+
+// Connect adds the route `pattern` that matches a CONNECT http method to
+// execute the `handlerFn` http.HandlerFunc.
+func (mx *Mux) Connect(pattern string, handlerFn http.HandlerFunc) {
+	mx.handle(mCONNECT, pattern, handlerFn)
+}
+
+// Delete adds the route `pattern` that matches a DELETE http method to
+// execute the `handlerFn` http.HandlerFunc.
+func (mx *Mux) Delete(pattern string, handlerFn http.HandlerFunc) {
+	mx.handle(mDELETE, pattern, handlerFn)
+}
+
+// Get adds the route `pattern` that matches a GET http method to
+// execute the `handlerFn` http.HandlerFunc.
+func (mx *Mux) Get(pattern string, handlerFn http.HandlerFunc) {
+	mx.handle(mGET, pattern, handlerFn)
+}
+
+// Head adds the route `pattern` that matches a HEAD http method to
+// execute the `handlerFn` http.HandlerFunc.
+func (mx *Mux) Head(pattern string, handlerFn http.HandlerFunc) {
+	mx.handle(mHEAD, pattern, handlerFn)
+}
+
+// Options adds the route `pattern` that matches an OPTIONS http method to
+// execute the `handlerFn` http.HandlerFunc.
+func (mx *Mux) Options(pattern string, handlerFn http.HandlerFunc) {
+	mx.handle(mOPTIONS, pattern, handlerFn)
+}
+
+// Patch adds the route `pattern` that matches a PATCH http method to
+// execute the `handlerFn` http.HandlerFunc.
+func (mx *Mux) Patch(pattern string, handlerFn http.HandlerFunc) {
+	mx.handle(mPATCH, pattern, handlerFn)
+}
+
+// Post adds the route `pattern` that matches a POST http method to
+// execute the `handlerFn` http.HandlerFunc.
+func (mx *Mux) Post(pattern string, handlerFn http.HandlerFunc) {
+	mx.handle(mPOST, pattern, handlerFn)
+}
+
+// Put adds the route `pattern` that matches a PUT http method to
+// execute the `handlerFn` http.HandlerFunc.
+func (mx *Mux) Put(pattern string, handlerFn http.HandlerFunc) {
+	mx.handle(mPUT, pattern, handlerFn)
+}
+
+// Trace adds the route `pattern` that matches a TRACE http method to
+// execute the `handlerFn` http.HandlerFunc.
+func (mx *Mux) Trace(pattern string, handlerFn http.HandlerFunc) {
+	mx.handle(mTRACE, pattern, handlerFn)
+}
+
+// NotFound sets a custom http.HandlerFunc for routing paths that could
+// not be found. The default 404 handler is `http.NotFound`.
+func (mx *Mux) NotFound(handlerFn http.HandlerFunc) {
+	// Build NotFound handler chain
+	m := mx
+	hFn := handlerFn
+	if mx.inline && mx.parent != nil {
+		m = mx.parent
+		hFn = Chain(mx.middlewares...).HandlerFunc(hFn).ServeHTTP
+	}
+
+	// Update the notFoundHandler from this point forward
+	m.notFoundHandler = hFn
+	m.updateSubRoutes(func(subMux *Mux) {
+		if subMux.notFoundHandler == nil {
+			subMux.NotFound(hFn)
+		}
+	})
+}
+
+// MethodNotAllowed sets a custom http.HandlerFunc for routing paths where the
+// method is unresolved. The default handler returns a 405 with an empty body.
+func (mx *Mux) MethodNotAllowed(handlerFn http.HandlerFunc) {
+	// Build MethodNotAllowed handler chain
+	m := mx
+	hFn := handlerFn
+	if mx.inline && mx.parent != nil {
+		m = mx.parent
+		hFn = Chain(mx.middlewares...).HandlerFunc(hFn).ServeHTTP
+	}
+
+	// Update the methodNotAllowedHandler from this point forward
+	m.methodNotAllowedHandler = hFn
+	m.updateSubRoutes(func(subMux *Mux) {
+		if subMux.methodNotAllowedHandler == nil {
+			subMux.MethodNotAllowed(hFn)
+		}
+	})
+}
+
+// With adds inline middlewares for an endpoint handler.
+func (mx *Mux) With(middlewares ...func(http.Handler) http.Handler) Router {
+	// Similarly as in handle(), we must build the mux handler once additional
+	// middleware registration isn't allowed for this stack, like now.
+	if !mx.inline && mx.handler == nil {
+		mx.updateRouteHandler()
+	}
+
+	// Copy middlewares from parent inline muxs
+	var mws Middlewares
+	if mx.inline {
+		mws = make(Middlewares, len(mx.middlewares))
+		copy(mws, mx.middlewares)
+	}
+	mws = append(mws, middlewares...)
+
+	im := &Mux{
+		pool: mx.pool, inline: true, parent: mx, tree: mx.tree, middlewares: mws,
+		notFoundHandler: mx.notFoundHandler, methodNotAllowedHandler: mx.methodNotAllowedHandler,
+	}
+
+	return im
+}
+
+// Group creates a new inline-Mux with a copy of middleware stack. It's useful
+// for a group of handlers along the same routing path that use an additional
+// set of middlewares. See _examples/.
+func (mx *Mux) Group(fn func(r Router)) Router {
+	im := mx.With()
+	if fn != nil {
+		fn(im)
+	}
+	return im
+}
+
+// Route creates a new Mux and mounts it along the `pattern` as a subrouter.
+// Effectively, this is a short-hand call to Mount. See _examples/.
+func (mx *Mux) Route(pattern string, fn func(r Router)) Router {
+	if fn == nil {
+		panic(fmt.Sprintf("chi: attempting to Route() a nil subrouter on '%s'", pattern))
+	}
+	subRouter := NewRouter()
+	fn(subRouter)
+	mx.Mount(pattern, subRouter)
+	return subRouter
+}
+
+// Mount attaches another http.Handler or chi Router as a subrouter along a routing
+// path. It's very useful to split up a large API as many independent routers and
+// compose them as a single service using Mount. See _examples/.
+//
+// Note that Mount() simply sets a wildcard along the `pattern` that will continue
+// routing at the `handler`, which in most cases is another chi.Router. As a result,
+// if you define two Mount() routes on the exact same pattern the mount will panic.
+func (mx *Mux) Mount(pattern string, handler http.Handler) {
+	if handler == nil {
+		panic(fmt.Sprintf("chi: attempting to Mount() a nil handler on '%s'", pattern))
+	}
+
+	// Provide runtime safety for ensuring a pattern isn't mounted on an existing
+	// routing pattern.
+	if mx.tree.findPattern(pattern+"*") || mx.tree.findPattern(pattern+"/*") {
+		panic(fmt.Sprintf("chi: attempting to Mount() a handler on an existing path, '%s'", pattern))
+	}
+
+	// Assign sub-Router's with the parent not found & method not allowed handler if not specified.
+	subr, ok := handler.(*Mux)
+	if ok && subr.notFoundHandler == nil && mx.notFoundHandler != nil {
+		subr.NotFound(mx.notFoundHandler)
+	}
+	if ok && subr.methodNotAllowedHandler == nil && mx.methodNotAllowedHandler != nil {
+		subr.MethodNotAllowed(mx.methodNotAllowedHandler)
+	}
+
+	mountHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rctx := RouteContext(r.Context())
+
+		// shift the url path past the previous subrouter
+		rctx.RoutePath = mx.nextRoutePath(rctx)
+
+		// reset the wildcard URLParam which connects the subrouter
+		n := len(rctx.URLParams.Keys) - 1
+		if n >= 0 && rctx.URLParams.Keys[n] == "*" && len(rctx.URLParams.Values) > n {
+			rctx.URLParams.Values[n] = ""
+		}
+
+		handler.ServeHTTP(w, r)
+	})
+
+	if pattern == "" || pattern[len(pattern)-1] != '/' {
+		mx.handle(mALL|mSTUB, pattern, mountHandler)
+		mx.handle(mALL|mSTUB, pattern+"/", mountHandler)
+		pattern += "/"
+	}
+
+	method := mALL
+	subroutes, _ := handler.(Routes)
+	if subroutes != nil {
+		method |= mSTUB
+	}
+	n := mx.handle(method, pattern+"*", mountHandler)
+
+	if subroutes != nil {
+		n.subroutes = subroutes
+	}
+}
+
+// Routes returns a slice of routing information from the tree,
+// useful for traversing available routes of a router.
+func (mx *Mux) Routes() []Route {
+	return mx.tree.routes()
+}
+
+// Middlewares returns a slice of middleware handler functions.
+func (mx *Mux) Middlewares() Middlewares {
+	return mx.middlewares
+}
+
+// Match searches the routing tree for a handler that matches the method/path.
+// It's similar to routing a http request, but without executing the handler
+// thereafter.
+//
+// Note: the *Context state is updated during execution, so manage
+// the state carefully or make a NewRouteContext().
+func (mx *Mux) Match(rctx *Context, method, path string) bool {
+	return mx.Find(rctx, method, path) != ""
+}
+
+// Find searches the routing tree for the pattern that matches
+// the method/path.
+//
+// Note: the *Context state is updated during execution, so manage
+// the state carefully or make a NewRouteContext().
+func (mx *Mux) Find(rctx *Context, method, path string) string {
+	m, ok := methodMap[method]
+	if !ok {
+		return ""
+	}
+
+	node, _, _ := mx.tree.FindRoute(rctx, m, path)
+	pattern := rctx.routePattern
+
+	if node != nil {
+		if node.subroutes == nil {
+			e := node.endpoints[m]
+			return e.pattern
+		}
+
+		rctx.RoutePath = mx.nextRoutePath(rctx)
+		subPattern := node.subroutes.Find(rctx, method, rctx.RoutePath)
+		if subPattern == "" {
+			return ""
+		}
+
+		pattern = strings.TrimSuffix(pattern, "/*")
+		pattern += subPattern
+	}
+
+	return pattern
+}
+
+// NotFoundHandler returns the default Mux 404 responder whenever a route
+// cannot be found.
+func (mx *Mux) NotFoundHandler() http.HandlerFunc {
+	if mx.notFoundHandler != nil {
+		return mx.notFoundHandler
+	}
+	return http.NotFound
+}
+
+// MethodNotAllowedHandler returns the default Mux 405 responder whenever
+// a method cannot be resolved for a route.
+func (mx *Mux) MethodNotAllowedHandler(methodsAllowed ...methodTyp) http.HandlerFunc {
+	if mx.methodNotAllowedHandler != nil {
+		return mx.methodNotAllowedHandler
+	}
+	return methodNotAllowedHandler(methodsAllowed...)
+}
+
+// handle registers a http.Handler in the routing tree for a particular http method
+// and routing pattern.
+func (mx *Mux) handle(method methodTyp, pattern string, handler http.Handler) *node {
+	if len(pattern) == 0 || pattern[0] != '/' {
+		panic(fmt.Sprintf("chi: routing pattern must begin with '/' in '%s'", pattern))
+	}
+
+	// Build the computed routing handler for this routing pattern.
+	if !mx.inline && mx.handler == nil {
+		mx.updateRouteHandler()
+	}
+
+	// Build endpoint handler with inline middlewares for the route
+	var h http.Handler
+	if mx.inline {
+		mx.handler = http.HandlerFunc(mx.routeHTTP)
+		h = Chain(mx.middlewares...).Handler(handler)
+	} else {
+		h = handler
+	}
+
+	// Add the endpoint to the tree and return the node
+	return mx.tree.InsertRoute(method, pattern, h)
+}
+
+// routeHTTP routes a http.Request through the Mux routing tree to serve
+// the matching handler for a particular http method.
+func (mx *Mux) routeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Grab the route context object
+	rctx := r.Context().Value(RouteCtxKey).(*Context)
+
+	// The request routing path
+	routePath := rctx.RoutePath
+	if routePath == "" {
+		if r.URL.RawPath != "" {
+			routePath = r.URL.RawPath
+		} else {
+			routePath = r.URL.Path
+		}
+		if routePath == "" {
+			routePath = "/"
+		}
+	}
+
+	// Check if method is supported by chi
+	if rctx.RouteMethod == "" {
+		rctx.RouteMethod = r.Method
+	}
+	method, ok := methodMap[rctx.RouteMethod]
+	if !ok {
+		mx.MethodNotAllowedHandler().ServeHTTP(w, r)
+		return
+	}
+
+	// Find the route
+	if _, _, h := mx.tree.FindRoute(rctx, method, routePath); h != nil {
+		// Set http.Request path values from our request context
+		for i, key := range rctx.URLParams.Keys {
+			value := rctx.URLParams.Values[i]
+			r.SetPathValue(key, value)
+		}
+		if supportsPattern {
+			setPattern(rctx, r)
+		}
+
+		h.ServeHTTP(w, r)
+		return
+	}
+	if rctx.methodNotAllowed {
+		mx.MethodNotAllowedHandler(rctx.methodsAllowed...).ServeHTTP(w, r)
+	} else {
+		mx.NotFoundHandler().ServeHTTP(w, r)
+	}
+}
+
+func (mx *Mux) nextRoutePath(rctx *Context) string {
+	routePath := "/"
+	nx := len(rctx.routeParams.Keys) - 1 // index of last param in list
+	if nx >= 0 && rctx.routeParams.Keys[nx] == "*" && len(rctx.routeParams.Values) > nx {
+		routePath = "/" + rctx.routeParams.Values[nx]
+	}
+	return routePath
+}
+
+// Recursively update data on child routers.
+func (mx *Mux) updateSubRoutes(fn func(subMux *Mux)) {
+	for _, r := range mx.tree.routes() {
+		subMux, ok := r.SubRoutes.(*Mux)
+		if !ok {
+			continue
+		}
+		fn(subMux)
+	}
+}
+
+// updateRouteHandler builds the single mux handler that is a chain of the middleware
+// stack, as defined by calls to Use(), and the tree router (Mux) itself. After this
+// point, no other middlewares can be registered on this Mux's stack. But you can still
+// compose additional middlewares via Group()'s or using a chained middleware handler.
+func (mx *Mux) updateRouteHandler() {
+	mx.handler = chain(mx.middlewares, http.HandlerFunc(mx.routeHTTP))
+}
+
+// methodNotAllowedHandler is a helper function to respond with a 405,
+// method not allowed. It sets the Allow header with the list of allowed
+// methods for the route.
+func methodNotAllowedHandler(methodsAllowed ...methodTyp) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		for _, m := range methodsAllowed {
+			w.Header().Add("Allow", reverseMethodMap[m])
+		}
+		w.WriteHeader(405)
+		w.Write(nil)
+	}
+}

--- a/vendor/github.com/go-chi/chi/v5/pattern.go
+++ b/vendor/github.com/go-chi/chi/v5/pattern.go
@@ -1,0 +1,16 @@
+//go:build go1.23 && !tinygo
+// +build go1.23,!tinygo
+
+package chi
+
+import "net/http"
+
+// supportsPattern is true if the Go version is 1.23 and above.
+//
+// If this is true, `net/http.Request` has field `Pattern`.
+const supportsPattern = true
+
+// setPattern sets the mux matched pattern in the http Request.
+func setPattern(rctx *Context, r *http.Request) {
+	r.Pattern = rctx.routePattern
+}

--- a/vendor/github.com/go-chi/chi/v5/pattern_fallback.go
+++ b/vendor/github.com/go-chi/chi/v5/pattern_fallback.go
@@ -1,0 +1,17 @@
+//go:build !go1.23 || tinygo
+// +build !go1.23 tinygo
+
+package chi
+
+import "net/http"
+
+// supportsPattern is true if the Go version is 1.23 and above.
+//
+// If this is true, `net/http.Request` has field `Pattern`.
+const supportsPattern = false
+
+// setPattern sets the mux matched pattern in the http Request.
+//
+// setPattern is only supported in Go 1.23 and above so
+// this is just a blank function so that it compiles.
+func setPattern(rctx *Context, r *http.Request) {}

--- a/vendor/github.com/go-chi/chi/v5/tree.go
+++ b/vendor/github.com/go-chi/chi/v5/tree.go
@@ -1,0 +1,872 @@
+package chi
+
+// Radix tree implementation below is a based on the original work by
+// Armon Dadgar in https://github.com/armon/go-radix/blob/master/radix.go
+// (MIT licensed). It's been heavily modified for use as a HTTP routing tree.
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type methodTyp uint
+
+const (
+	mSTUB methodTyp = 1 << iota
+	mCONNECT
+	mDELETE
+	mGET
+	mHEAD
+	mOPTIONS
+	mPATCH
+	mPOST
+	mPUT
+	mTRACE
+)
+
+var mALL = mCONNECT | mDELETE | mGET | mHEAD |
+	mOPTIONS | mPATCH | mPOST | mPUT | mTRACE
+
+var methodMap = map[string]methodTyp{
+	http.MethodConnect: mCONNECT,
+	http.MethodDelete:  mDELETE,
+	http.MethodGet:     mGET,
+	http.MethodHead:    mHEAD,
+	http.MethodOptions: mOPTIONS,
+	http.MethodPatch:   mPATCH,
+	http.MethodPost:    mPOST,
+	http.MethodPut:     mPUT,
+	http.MethodTrace:   mTRACE,
+}
+
+var reverseMethodMap = map[methodTyp]string{
+	mCONNECT: http.MethodConnect,
+	mDELETE:  http.MethodDelete,
+	mGET:     http.MethodGet,
+	mHEAD:    http.MethodHead,
+	mOPTIONS: http.MethodOptions,
+	mPATCH:   http.MethodPatch,
+	mPOST:    http.MethodPost,
+	mPUT:     http.MethodPut,
+	mTRACE:   http.MethodTrace,
+}
+
+// RegisterMethod adds support for custom HTTP method handlers, available
+// via Router#Method and Router#MethodFunc
+func RegisterMethod(method string) {
+	if method == "" {
+		return
+	}
+	method = strings.ToUpper(method)
+	if _, ok := methodMap[method]; ok {
+		return
+	}
+	n := len(methodMap)
+	if n > strconv.IntSize-2 {
+		panic(fmt.Sprintf("chi: max number of methods reached (%d)", strconv.IntSize))
+	}
+	mt := methodTyp(2 << n)
+	methodMap[method] = mt
+	reverseMethodMap[mt] = method
+	mALL |= mt
+}
+
+type nodeTyp uint8
+
+const (
+	ntStatic   nodeTyp = iota // /home
+	ntRegexp                  // /{id:[0-9]+}
+	ntParam                   // /{user}
+	ntCatchAll                // /api/v1/*
+)
+
+type node struct {
+	// subroutes on the leaf node
+	subroutes Routes
+
+	// regexp matcher for regexp nodes
+	rex *regexp.Regexp
+
+	// HTTP handler endpoints on the leaf node
+	endpoints endpoints
+
+	// prefix is the common prefix we ignore
+	prefix string
+
+	// child nodes should be stored in-order for iteration,
+	// in groups of the node type.
+	children [ntCatchAll + 1]nodes
+
+	// first byte of the child prefix
+	tail byte
+
+	// node type: static, regexp, param, catchAll
+	typ nodeTyp
+
+	// first byte of the prefix
+	label byte
+}
+
+// endpoints is a mapping of http method constants to handlers
+// for a given route.
+type endpoints map[methodTyp]*endpoint
+
+type endpoint struct {
+	// endpoint handler
+	handler http.Handler
+
+	// pattern is the routing pattern for handler nodes
+	pattern string
+
+	// parameter keys recorded on handler nodes
+	paramKeys []string
+}
+
+func (s endpoints) Value(method methodTyp) *endpoint {
+	mh, ok := s[method]
+	if !ok {
+		mh = &endpoint{}
+		s[method] = mh
+	}
+	return mh
+}
+
+func (n *node) InsertRoute(method methodTyp, pattern string, handler http.Handler) *node {
+	var parent *node
+	search := pattern
+
+	for {
+		// Handle key exhaustion
+		if len(search) == 0 {
+			// Insert or update the node's leaf handler
+			n.setEndpoint(method, handler, pattern)
+			return n
+		}
+
+		// We're going to be searching for a wild node next,
+		// in this case, we need to get the tail
+		var label = search[0]
+		var segTail byte
+		var segEndIdx int
+		var segTyp nodeTyp
+		var segRexpat string
+		if label == '{' || label == '*' {
+			segTyp, _, segRexpat, segTail, _, segEndIdx = patNextSegment(search)
+		}
+
+		var prefix string
+		if segTyp == ntRegexp {
+			prefix = segRexpat
+		}
+
+		// Look for the edge to attach to
+		parent = n
+		n = n.getEdge(segTyp, label, segTail, prefix)
+
+		// No edge, create one
+		if n == nil {
+			child := &node{label: label, tail: segTail, prefix: search}
+			hn := parent.addChild(child, search)
+			hn.setEndpoint(method, handler, pattern)
+
+			return hn
+		}
+
+		// Found an edge to match the pattern
+
+		if n.typ > ntStatic {
+			// We found a param node, trim the param from the search path and continue.
+			// This param/wild pattern segment would already be on the tree from a previous
+			// call to addChild when creating a new node.
+			search = search[segEndIdx:]
+			continue
+		}
+
+		// Static nodes fall below here.
+		// Determine longest prefix of the search key on match.
+		commonPrefix := longestPrefix(search, n.prefix)
+		if commonPrefix == len(n.prefix) {
+			// the common prefix is as long as the current node's prefix we're attempting to insert.
+			// keep the search going.
+			search = search[commonPrefix:]
+			continue
+		}
+
+		// Split the node
+		child := &node{
+			typ:    ntStatic,
+			prefix: search[:commonPrefix],
+		}
+		parent.replaceChild(search[0], segTail, child)
+
+		// Restore the existing node
+		n.label = n.prefix[commonPrefix]
+		n.prefix = n.prefix[commonPrefix:]
+		child.addChild(n, n.prefix)
+
+		// If the new key is a subset, set the method/handler on this node and finish.
+		search = search[commonPrefix:]
+		if len(search) == 0 {
+			child.setEndpoint(method, handler, pattern)
+			return child
+		}
+
+		// Create a new edge for the node
+		subchild := &node{
+			typ:    ntStatic,
+			label:  search[0],
+			prefix: search,
+		}
+		hn := child.addChild(subchild, search)
+		hn.setEndpoint(method, handler, pattern)
+		return hn
+	}
+}
+
+// addChild appends the new `child` node to the tree using the `pattern` as the trie key.
+// For a URL router like chi's, we split the static, param, regexp and wildcard segments
+// into different nodes. In addition, addChild will recursively call itself until every
+// pattern segment is added to the url pattern tree as individual nodes, depending on type.
+func (n *node) addChild(child *node, prefix string) *node {
+	search := prefix
+
+	// handler leaf node added to the tree is the child.
+	// this may be overridden later down the flow
+	hn := child
+
+	// Parse next segment
+	segTyp, _, segRexpat, segTail, segStartIdx, segEndIdx := patNextSegment(search)
+
+	// Add child depending on next up segment
+	switch segTyp {
+
+	case ntStatic:
+		// Search prefix is all static (that is, has no params in path)
+		// noop
+
+	default:
+		// Search prefix contains a param, regexp or wildcard
+
+		if segTyp == ntRegexp {
+			rex, err := regexp.Compile(segRexpat)
+			if err != nil {
+				panic(fmt.Sprintf("chi: invalid regexp pattern '%s' in route param", segRexpat))
+			}
+			child.prefix = segRexpat
+			child.rex = rex
+		}
+
+		if segStartIdx == 0 {
+			// Route starts with a param
+			child.typ = segTyp
+
+			if segTyp == ntCatchAll {
+				segStartIdx = -1
+			} else {
+				segStartIdx = segEndIdx
+			}
+			if segStartIdx < 0 {
+				segStartIdx = len(search)
+			}
+			child.tail = segTail // for params, we set the tail
+
+			if segStartIdx != len(search) {
+				// add static edge for the remaining part, split the end.
+				// its not possible to have adjacent param nodes, so its certainly
+				// going to be a static node next.
+
+				search = search[segStartIdx:] // advance search position
+
+				nn := &node{
+					typ:    ntStatic,
+					label:  search[0],
+					prefix: search,
+				}
+				hn = child.addChild(nn, search)
+			}
+
+		} else if segStartIdx > 0 {
+			// Route has some param
+
+			// starts with a static segment
+			child.typ = ntStatic
+			child.prefix = search[:segStartIdx]
+			child.rex = nil
+
+			// add the param edge node
+			search = search[segStartIdx:]
+
+			nn := &node{
+				typ:   segTyp,
+				label: search[0],
+				tail:  segTail,
+			}
+			hn = child.addChild(nn, search)
+
+		}
+	}
+
+	n.children[child.typ] = append(n.children[child.typ], child)
+	n.children[child.typ].Sort()
+	return hn
+}
+
+func (n *node) replaceChild(label, tail byte, child *node) {
+	for i := 0; i < len(n.children[child.typ]); i++ {
+		if n.children[child.typ][i].label == label && n.children[child.typ][i].tail == tail {
+			n.children[child.typ][i] = child
+			n.children[child.typ][i].label = label
+			n.children[child.typ][i].tail = tail
+			return
+		}
+	}
+	panic("chi: replacing missing child")
+}
+
+func (n *node) getEdge(ntyp nodeTyp, label, tail byte, prefix string) *node {
+	nds := n.children[ntyp]
+	for i := range nds {
+		if nds[i].label == label && nds[i].tail == tail {
+			if ntyp == ntRegexp && nds[i].prefix != prefix {
+				continue
+			}
+			return nds[i]
+		}
+	}
+	return nil
+}
+
+func (n *node) setEndpoint(method methodTyp, handler http.Handler, pattern string) {
+	// Set the handler for the method type on the node
+	if n.endpoints == nil {
+		n.endpoints = make(endpoints)
+	}
+
+	paramKeys := patParamKeys(pattern)
+
+	if method&mSTUB == mSTUB {
+		n.endpoints.Value(mSTUB).handler = handler
+	}
+	if method&mALL == mALL {
+		h := n.endpoints.Value(mALL)
+		h.handler = handler
+		h.pattern = pattern
+		h.paramKeys = paramKeys
+		for _, m := range methodMap {
+			h := n.endpoints.Value(m)
+			h.handler = handler
+			h.pattern = pattern
+			h.paramKeys = paramKeys
+		}
+	} else {
+		h := n.endpoints.Value(method)
+		h.handler = handler
+		h.pattern = pattern
+		h.paramKeys = paramKeys
+	}
+}
+
+func (n *node) FindRoute(rctx *Context, method methodTyp, path string) (*node, endpoints, http.Handler) {
+	// Reset the context routing pattern and params
+	rctx.routePattern = ""
+	rctx.routeParams.Keys = rctx.routeParams.Keys[:0]
+	rctx.routeParams.Values = rctx.routeParams.Values[:0]
+
+	// Find the routing handlers for the path
+	rn := n.findRoute(rctx, method, path)
+	if rn == nil {
+		return nil, nil, nil
+	}
+
+	// Record the routing params in the request lifecycle
+	rctx.URLParams.Keys = append(rctx.URLParams.Keys, rctx.routeParams.Keys...)
+	rctx.URLParams.Values = append(rctx.URLParams.Values, rctx.routeParams.Values...)
+
+	// Record the routing pattern in the request lifecycle
+	if rn.endpoints[method].pattern != "" {
+		rctx.routePattern = rn.endpoints[method].pattern
+		rctx.RoutePatterns = append(rctx.RoutePatterns, rctx.routePattern)
+	}
+
+	return rn, rn.endpoints, rn.endpoints[method].handler
+}
+
+// Recursive edge traversal by checking all nodeTyp groups along the way.
+// It's like searching through a multi-dimensional radix trie.
+func (n *node) findRoute(rctx *Context, method methodTyp, path string) *node {
+	nn := n
+	search := path
+
+	for t, nds := range nn.children {
+		ntyp := nodeTyp(t)
+		if len(nds) == 0 {
+			continue
+		}
+
+		var xn *node
+		xsearch := search
+
+		var label byte
+		if search != "" {
+			label = search[0]
+		}
+
+		switch ntyp {
+		case ntStatic:
+			xn = nds.findEdge(label)
+			if xn == nil || !strings.HasPrefix(xsearch, xn.prefix) {
+				continue
+			}
+			xsearch = xsearch[len(xn.prefix):]
+
+		case ntParam, ntRegexp:
+			// short-circuit and return no matching route for empty param values
+			if xsearch == "" {
+				continue
+			}
+
+			// serially loop through each node grouped by the tail delimiter
+			for _, xn = range nds {
+				// label for param nodes is the delimiter byte
+				p := strings.IndexByte(xsearch, xn.tail)
+
+				if p < 0 {
+					if xn.tail == '/' {
+						p = len(xsearch)
+					} else {
+						continue
+					}
+				} else if ntyp == ntRegexp && p == 0 {
+					continue
+				}
+
+				if ntyp == ntRegexp && xn.rex != nil {
+					if !xn.rex.MatchString(xsearch[:p]) {
+						continue
+					}
+				} else if strings.IndexByte(xsearch[:p], '/') != -1 {
+					// avoid a match across path segments
+					continue
+				}
+
+				prevlen := len(rctx.routeParams.Values)
+				rctx.routeParams.Values = append(rctx.routeParams.Values, xsearch[:p])
+				xsearch = xsearch[p:]
+
+				if len(xsearch) == 0 {
+					if xn.isLeaf() {
+						h := xn.endpoints[method]
+						if h != nil && h.handler != nil {
+							rctx.routeParams.Keys = append(rctx.routeParams.Keys, h.paramKeys...)
+							return xn
+						}
+
+						for endpoints := range xn.endpoints {
+							if endpoints == mALL || endpoints == mSTUB {
+								continue
+							}
+							rctx.methodsAllowed = append(rctx.methodsAllowed, endpoints)
+						}
+
+						// flag that the routing context found a route, but not a corresponding
+						// supported method
+						rctx.methodNotAllowed = true
+					}
+				}
+
+				// recursively find the next node on this branch
+				fin := xn.findRoute(rctx, method, xsearch)
+				if fin != nil {
+					return fin
+				}
+
+				// not found on this branch, reset vars
+				rctx.routeParams.Values = rctx.routeParams.Values[:prevlen]
+				xsearch = search
+			}
+
+			rctx.routeParams.Values = append(rctx.routeParams.Values, "")
+
+		default:
+			// catch-all nodes
+			rctx.routeParams.Values = append(rctx.routeParams.Values, search)
+			xn = nds[0]
+			xsearch = ""
+		}
+
+		if xn == nil {
+			continue
+		}
+
+		// did we find it yet?
+		if len(xsearch) == 0 {
+			if xn.isLeaf() {
+				h := xn.endpoints[method]
+				if h != nil && h.handler != nil {
+					rctx.routeParams.Keys = append(rctx.routeParams.Keys, h.paramKeys...)
+					return xn
+				}
+
+				for endpoints := range xn.endpoints {
+					if endpoints == mALL || endpoints == mSTUB {
+						continue
+					}
+					rctx.methodsAllowed = append(rctx.methodsAllowed, endpoints)
+				}
+
+				// flag that the routing context found a route, but not a corresponding
+				// supported method
+				rctx.methodNotAllowed = true
+			}
+		}
+
+		// recursively find the next node..
+		fin := xn.findRoute(rctx, method, xsearch)
+		if fin != nil {
+			return fin
+		}
+
+		// Did not find final handler, let's remove the param here if it was set
+		if xn.typ > ntStatic {
+			if len(rctx.routeParams.Values) > 0 {
+				rctx.routeParams.Values = rctx.routeParams.Values[:len(rctx.routeParams.Values)-1]
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (n *node) findEdge(ntyp nodeTyp, label byte) *node {
+	nds := n.children[ntyp]
+	num := len(nds)
+	idx := 0
+
+	switch ntyp {
+	case ntStatic, ntParam, ntRegexp:
+		i, j := 0, num-1
+		for i <= j {
+			idx = i + (j-i)/2
+			if label > nds[idx].label {
+				i = idx + 1
+			} else if label < nds[idx].label {
+				j = idx - 1
+			} else {
+				i = num // breaks cond
+			}
+		}
+		if nds[idx].label != label {
+			return nil
+		}
+		return nds[idx]
+
+	default: // catch all
+		return nds[idx]
+	}
+}
+
+func (n *node) isLeaf() bool {
+	return n.endpoints != nil
+}
+
+func (n *node) findPattern(pattern string) bool {
+	nn := n
+	for _, nds := range nn.children {
+		if len(nds) == 0 {
+			continue
+		}
+
+		n = nn.findEdge(nds[0].typ, pattern[0])
+		if n == nil {
+			continue
+		}
+
+		var idx int
+		var xpattern string
+
+		switch n.typ {
+		case ntStatic:
+			idx = longestPrefix(pattern, n.prefix)
+			if idx < len(n.prefix) {
+				continue
+			}
+
+		case ntParam, ntRegexp:
+			idx = strings.IndexByte(pattern, '}') + 1
+
+		case ntCatchAll:
+			idx = longestPrefix(pattern, "*")
+
+		default:
+			panic("chi: unknown node type")
+		}
+
+		xpattern = pattern[idx:]
+		if len(xpattern) == 0 {
+			return true
+		}
+
+		return n.findPattern(xpattern)
+	}
+	return false
+}
+
+func (n *node) routes() []Route {
+	rts := []Route{}
+
+	n.walk(func(eps endpoints, subroutes Routes) bool {
+		if eps[mSTUB] != nil && eps[mSTUB].handler != nil && subroutes == nil {
+			return false
+		}
+
+		// Group methodHandlers by unique patterns
+		pats := make(map[string]endpoints)
+
+		for mt, h := range eps {
+			if h.pattern == "" {
+				continue
+			}
+			p, ok := pats[h.pattern]
+			if !ok {
+				p = endpoints{}
+				pats[h.pattern] = p
+			}
+			p[mt] = h
+		}
+
+		for p, mh := range pats {
+			hs := make(map[string]http.Handler)
+			if mh[mALL] != nil && mh[mALL].handler != nil {
+				hs["*"] = mh[mALL].handler
+			}
+
+			for mt, h := range mh {
+				if h.handler == nil {
+					continue
+				}
+				if m, ok := reverseMethodMap[mt]; ok {
+					hs[m] = h.handler
+				}
+			}
+
+			rt := Route{subroutes, hs, p}
+			rts = append(rts, rt)
+		}
+
+		return false
+	})
+
+	return rts
+}
+
+func (n *node) walk(fn func(eps endpoints, subroutes Routes) bool) bool {
+	// Visit the leaf values if any
+	if (n.endpoints != nil || n.subroutes != nil) && fn(n.endpoints, n.subroutes) {
+		return true
+	}
+
+	// Recurse on the children
+	for _, ns := range n.children {
+		for _, cn := range ns {
+			if cn.walk(fn) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// patNextSegment returns the next segment details from a pattern:
+// node type, param key, regexp string, param tail byte, param starting index, param ending index
+func patNextSegment(pattern string) (nodeTyp, string, string, byte, int, int) {
+	ps := strings.Index(pattern, "{")
+	ws := strings.Index(pattern, "*")
+
+	if ps < 0 && ws < 0 {
+		return ntStatic, "", "", 0, 0, len(pattern) // we return the entire thing
+	}
+
+	// Sanity check
+	if ps >= 0 && ws >= 0 && ws < ps {
+		panic("chi: wildcard '*' must be the last pattern in a route, otherwise use a '{param}'")
+	}
+
+	var tail byte = '/' // Default endpoint tail to / byte
+
+	if ps >= 0 {
+		// Param/Regexp pattern is next
+		nt := ntParam
+
+		// Read to closing } taking into account opens and closes in curl count (cc)
+		cc := 0
+		pe := ps
+		for i, c := range pattern[ps:] {
+			if c == '{' {
+				cc++
+			} else if c == '}' {
+				cc--
+				if cc == 0 {
+					pe = ps + i
+					break
+				}
+			}
+		}
+		if pe == ps {
+			panic("chi: route param closing delimiter '}' is missing")
+		}
+
+		key := pattern[ps+1 : pe]
+		pe++ // set end to next position
+
+		if pe < len(pattern) {
+			tail = pattern[pe]
+		}
+
+		key, rexpat, isRegexp := strings.Cut(key, ":")
+		if isRegexp {
+			nt = ntRegexp
+		}
+
+		if len(rexpat) > 0 {
+			if rexpat[0] != '^' {
+				rexpat = "^" + rexpat
+			}
+			if rexpat[len(rexpat)-1] != '$' {
+				rexpat += "$"
+			}
+		}
+
+		return nt, key, rexpat, tail, ps, pe
+	}
+
+	// Wildcard pattern as finale
+	if ws < len(pattern)-1 {
+		panic("chi: wildcard '*' must be the last value in a route. trim trailing text or use a '{param}' instead")
+	}
+	return ntCatchAll, "*", "", 0, ws, len(pattern)
+}
+
+func patParamKeys(pattern string) []string {
+	pat := pattern
+	paramKeys := []string{}
+	for {
+		ptyp, paramKey, _, _, _, e := patNextSegment(pat)
+		if ptyp == ntStatic {
+			return paramKeys
+		}
+		for i := 0; i < len(paramKeys); i++ {
+			if paramKeys[i] == paramKey {
+				panic(fmt.Sprintf("chi: routing pattern '%s' contains duplicate param key, '%s'", pattern, paramKey))
+			}
+		}
+		paramKeys = append(paramKeys, paramKey)
+		pat = pat[e:]
+	}
+}
+
+// longestPrefix finds the length of the shared prefix of two strings
+func longestPrefix(k1, k2 string) (i int) {
+	for i = 0; i < min(len(k1), len(k2)); i++ {
+		if k1[i] != k2[i] {
+			break
+		}
+	}
+	return
+}
+
+type nodes []*node
+
+// Sort the list of nodes by label
+func (ns nodes) Sort()              { sort.Sort(ns); ns.tailSort() }
+func (ns nodes) Len() int           { return len(ns) }
+func (ns nodes) Swap(i, j int)      { ns[i], ns[j] = ns[j], ns[i] }
+func (ns nodes) Less(i, j int) bool { return ns[i].label < ns[j].label }
+
+// tailSort pushes nodes with '/' as the tail to the end of the list for param nodes.
+// The list order determines the traversal order.
+func (ns nodes) tailSort() {
+	for i := len(ns) - 1; i >= 0; i-- {
+		if ns[i].typ > ntStatic && ns[i].tail == '/' {
+			ns.Swap(i, len(ns)-1)
+			return
+		}
+	}
+}
+
+func (ns nodes) findEdge(label byte) *node {
+	num := len(ns)
+	idx := 0
+	i, j := 0, num-1
+	for i <= j {
+		idx = i + (j-i)/2
+		if label > ns[idx].label {
+			i = idx + 1
+		} else if label < ns[idx].label {
+			j = idx - 1
+		} else {
+			i = num // breaks cond
+		}
+	}
+	if ns[idx].label != label {
+		return nil
+	}
+	return ns[idx]
+}
+
+// Route describes the details of a routing handler.
+// Handlers map key is an HTTP method
+type Route struct {
+	SubRoutes Routes
+	Handlers  map[string]http.Handler
+	Pattern   string
+}
+
+// WalkFunc is the type of the function called for each method and route visited by Walk.
+type WalkFunc func(method string, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error
+
+// Walk walks any router tree that implements Routes interface.
+func Walk(r Routes, walkFn WalkFunc) error {
+	return walk(r, walkFn, "")
+}
+
+func walk(r Routes, walkFn WalkFunc, parentRoute string, parentMw ...func(http.Handler) http.Handler) error {
+	for _, route := range r.Routes() {
+		mws := make([]func(http.Handler) http.Handler, len(parentMw))
+		copy(mws, parentMw)
+		mws = append(mws, r.Middlewares()...)
+
+		if route.SubRoutes != nil {
+			if err := walk(route.SubRoutes, walkFn, parentRoute+route.Pattern, mws...); err != nil {
+				return err
+			}
+			continue
+		}
+
+		for method, handler := range route.Handlers {
+			if method == "*" {
+				// Ignore a "catchAll" method, since we pass down all the specific methods for each route.
+				continue
+			}
+
+			fullRoute := parentRoute + route.Pattern
+			fullRoute = strings.Replace(fullRoute, "/*/", "/", -1)
+
+			if chain, ok := handler.(*ChainHandler); ok {
+				if err := walkFn(method, fullRoute, chain.Endpoint, append(mws, chain.Middlewares...)...); err != nil {
+					return err
+				}
+			} else {
+				if err := walkFn(method, fullRoute, handler, mws...); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -26,6 +26,9 @@ github.com/cyberdelia/go-metrics-graphite
 # github.com/fatih/color v1.19.0
 ## explicit; go 1.25.0
 github.com/fatih/color
+# github.com/go-chi/chi/v5 v5.2.5
+## explicit; go 1.22
+github.com/go-chi/chi/v5
 # github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab
 ## explicit
 github.com/go-martini/martini


### PR DESCRIPTION
## Summary

- Introduces `/api/v2/` endpoints with a standard JSON response envelope (`status`, `data`, `error`, `message`) and proper HTTP status codes (404, 400, 500, 503)
- Adds 9 read-only endpoints: clusters, cluster info, cluster instances, instance details, topology, recoveries, active recoveries, status, and ProxySQL servers
- Composes a chi router alongside the existing Martini handler so v1 API remains fully functional with zero changes

## Details

The v2 API addresses the inconsistency in v1 where some endpoints return raw JSON, some return strings, and all return HTTP 200 regardless of success or failure. Each v2 handler reuses existing domain logic from `go/inst` and `go/logic` packages.

New files:
- `go/http/apiv2.go` — v2 response envelope types, helper functions, route registration, and all handler implementations
- `go/http/apiv2_test.go` — 8 tests covering the response envelope structure, helper functions, and route registration
- `docs/api-v2.md` — full documentation with endpoint descriptions and request/response examples

Modified files:
- `go/app/http.go` — mounts the chi v2 router alongside Martini using a composing handler
- `go.mod` / `go.sum` / `vendor/` — adds `github.com/go-chi/chi/v5` dependency

Closes #33

## Test plan

- [x] `go build -o /dev/null ./go/cmd/orchestrator` compiles successfully
- [x] `go test ./go/http/...` — all 15 tests pass (8 new + 7 existing)
- [ ] Manual testing: start orchestrator and verify `/api/v2/clusters`, `/api/v2/status` return proper envelope format
- [ ] Verify v1 endpoints (`/api/clusters`, `/api/health`) still work unchanged