### PR TITLE
Add PostgreSQL documentation and tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ![Orchestrator logo](docs/images/orchestrator-logo-wide.png)
 
-`orchestrator` is a MySQL high availability and replication management tool, runs as a service and provides command line access, HTTP API and Web interface. `orchestrator` supports:
+`orchestrator` is a MySQL and PostgreSQL high availability and replication management tool, runs as a service and provides command line access, HTTP API and Web interface. `orchestrator` supports:
 
 #### Discovery
 
@@ -71,7 +71,8 @@ See [Observability documentation](docs/observability.md) and [API v2 documentati
 - Manual and automated failovers with full audit trail
 - Pseudo-GTID and Oracle GTID support
 - Datacenter/physical location awareness
-- Database provider abstraction for future multi-database support
+- **PostgreSQL support** -- discovery, failure detection, and automated failover for PostgreSQL streaming replication topologies
+- Database provider abstraction for multi-database support
 - HTTP security/authentication methods
 
 Read the [Orchestrator documentation](https://github.com/proxysql/orchestrator/tree/master/docs)

--- a/docs/database-providers.md
+++ b/docs/database-providers.md
@@ -6,9 +6,10 @@ Orchestrator supports a database provider abstraction layer that decouples core
 orchestration logic from database-specific operations. This allows orchestrator
 to manage different database engines through a common interface.
 
-MySQL is the default provider. PostgreSQL is also supported for streaming
-replication topologies. The abstraction layer is designed to support additional
-providers in the future.
+MySQL is the default provider. PostgreSQL is fully supported for streaming
+replication topologies, including discovery, failure detection, and automated
+failover. The abstraction layer is designed to support additional providers in
+the future.
 
 ## Architecture
 
@@ -87,53 +88,100 @@ is needed to use it.
 
 The PostgreSQL provider (`PostgreSQLProvider`) supports PostgreSQL streaming
 replication topologies. It uses the `lib/pq` driver to connect to PostgreSQL
-instances.
+instances and provides full support for discovery, failure detection, and
+automated failover.
 
-### Configuration
+### Switching to PostgreSQL Mode
 
-Add the following fields to your orchestrator configuration JSON:
+Set `ProviderType` to `"postgresql"` in your orchestrator configuration:
 
 ```json
 {
+  "ProviderType": "postgresql",
   "PostgreSQLTopologyUser": "orchestrator",
-  "PostgreSQLTopologyPassword": "secret"
+  "PostgreSQLTopologyPassword": "secret",
+  "PostgreSQLSSLMode": "require",
+  "DefaultInstancePort": 5432
 }
 ```
 
-These credentials are used to connect to PostgreSQL topology instances for
-discovery and replication management operations.
+When `ProviderType` is set to `"postgresql"`, orchestrator automatically uses
+the PostgreSQL provider for all topology operations: discovery, failure
+analysis, and recovery.
 
-### Activating the Provider
+### Configuration Fields
 
-To use PostgreSQL instead of MySQL, register the provider during startup:
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ProviderType` | string | `"mysql"` | Set to `"postgresql"` to enable PostgreSQL mode |
+| `PostgreSQLTopologyUser` | string | `""` | Username for connecting to PostgreSQL instances |
+| `PostgreSQLTopologyPassword` | string | `""` | Password for connecting to PostgreSQL instances |
+| `PostgreSQLSSLMode` | string | `"require"` | SSL mode: `disable`, `require`, `verify-ca`, `verify-full` |
 
-```go
-import "github.com/proxysql/orchestrator/go/inst"
+The orchestrator user on PostgreSQL needs the `pg_monitor` role:
 
-inst.SetProvider(inst.NewPostgreSQLProvider())
+```sql
+CREATE USER orchestrator WITH PASSWORD 'secret';
+GRANT pg_monitor TO orchestrator;
 ```
 
-### How It Works
+### Supported Operations
 
-| Operation           | PostgreSQL Implementation                                     |
-|---------------------|---------------------------------------------------------------|
+| Operation | PostgreSQL Implementation |
+|-----------|--------------------------|
+| **Discovery (primary)** | Queries `pg_current_wal_lsn()` for WAL position and `pg_stat_replication` to discover connected standbys. |
+| **Discovery (standby)** | Queries `pg_stat_wal_receiver` for WAL receiver status and `pg_last_wal_replay_lsn()` for replay position. Extracts primary host/port from `conninfo`. |
+| **Replication lag** | Computes `EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp())` on standbys. |
+| **Failure detection** | Analyzes reachability of primary and replication status of standbys. Produces `DeadPrimary`, `DeadPrimaryAndSomeStandbys`, `StandbyNotReplicating`, `AllStandbyNotReplicating`, and `UnreachablePrimary` analysis codes. |
+| **Promotion** | Calls `pg_promote(true, 60)` on the selected standby and waits up to 30 seconds for it to exit recovery mode. |
+| **Standby reconfiguration** | Updates `primary_conninfo` via `ALTER SYSTEM`, calls `pg_reload_conf()`, and pauses/resumes WAL replay to force reconnection. |
+| **Best standby selection** | Prefers standbys with: valid last check, replication running, lowest lag, highest WAL LSN, not downtimed. A candidate key is preferred if specified and valid. |
 | GetReplicationStatus | Queries `pg_stat_wal_receiver` (standby) or `pg_current_wal_lsn()` (primary). Reports WAL LSN as position and `replay_lag` as lag. |
-| IsReplicaRunning    | Checks `pg_stat_wal_receiver` for an active WAL receiver with `status = 'streaming'`. |
-| SetReadOnly         | Runs `ALTER SYSTEM SET default_transaction_read_only = on/off` followed by `SELECT pg_reload_conf()`. |
-| IsReadOnly          | Queries `SHOW default_transaction_read_only`.                 |
-| StartReplication    | Calls `SELECT pg_wal_replay_resume()`. Streaming replication itself starts automatically when the standby connects. |
-| StopReplication     | Calls `SELECT pg_wal_replay_pause()` to pause WAL replay. The WAL receiver remains connected. |
+| IsReplicaRunning | Checks `pg_stat_wal_receiver` for an active WAL receiver with `status = 'streaming'`. |
+| SetReadOnly | Runs `ALTER SYSTEM SET default_transaction_read_only = on/off` followed by `SELECT pg_reload_conf()`. |
+| IsReadOnly | Queries `SHOW default_transaction_read_only`. |
+| StartReplication | Calls `SELECT pg_wal_replay_resume()`. Streaming replication itself starts automatically when the standby connects. |
+| StopReplication | Calls `SELECT pg_wal_replay_pause()` to pause WAL replay. The WAL receiver remains connected. |
 
-### Differences from MySQL
+### Differences from MySQL Mode
 
 - **No separate IO/SQL threads.** PostgreSQL does not have the concept of
-  separate IO and SQL threads. The `IOThreadRunning` and `SQLThreadRunning`
-  fields in `ReplicationStatus` both mirror the WAL receiver state.
+  separate IO and SQL threads. The WAL receiver handles both receiving and
+  applying. Orchestrator maps the WAL receiver status to both the IO and SQL
+  thread fields.
+- **No intermediate masters.** PostgreSQL streaming replication uses a flat
+  primary-standby topology. There is no equivalent of MySQL intermediate masters.
+  Orchestrator treats all standbys as direct replicas of the primary.
+- **WAL-based positioning.** PostgreSQL uses WAL LSN (Log Sequence Number)
+  instead of binlog file:position or GTIDs. Orchestrator converts LSN to an
+  int64 for internal use.
 - **Streaming replication is automatic.** `StartReplication` resumes WAL replay
   but cannot start the WAL receiver itself -- that is controlled by PostgreSQL's
   `primary_conninfo` configuration.
 - **StopReplication pauses replay only.** The WAL receiver continues to receive
   WAL segments; only application (replay) is paused.
+- **Promotion uses `pg_promote()`.** Available since PostgreSQL 12. Orchestrator
+  calls `pg_promote(true, 60)` which waits for promotion to complete.
+- **Reconfiguration uses `ALTER SYSTEM`.** To repoint a standby, orchestrator
+  updates `primary_conninfo` via `ALTER SYSTEM SET` and reloads the config.
+- **No topology refactoring.** Moving replicas between masters (drag-and-drop in
+  the UI) is not supported in PostgreSQL mode. Only failover and standby
+  reconfiguration are available.
+- **No ProxySQL integration.** ProxySQL hooks are MySQL-specific. Use PgBouncer
+  or another PostgreSQL-aware connection pooler.
+
+### Limitations and Known Issues
+
+- **Cascading replication** (standby replicating from another standby) is not
+  currently detected or managed.
+- **Logical replication** is not supported -- only physical streaming replication.
+- **Synchronous replication** settings are not managed by orchestrator. If you
+  use `synchronous_standby_names`, you must manage it separately.
+- **`client_port` from `pg_stat_replication`** is an ephemeral port, not the
+  PostgreSQL listen port. Orchestrator uses `DefaultInstancePort` for standby
+  discovery, so all instances must listen on the same port.
+- **Graceful master takeover** (planned switchover) is not yet implemented for
+  PostgreSQL. Only unplanned failover (dead primary) is supported.
 
 ## Implementing a New Provider
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -103,6 +103,7 @@ Orchestrator is configured via a JSON file. All fields belong to the `Configurat
 |-------|------|---------|-------------|
 | `Debug` | bool | `false` | Set debug mode (similar to `--debug` option) |
 | `EnableSyslog` | bool | `false` | Should logs be directed (in addition) to syslog daemon? |
+| `ProviderType` | string | `"mysql"` | Database provider type: `"mysql"` (default) or `"postgresql"`. When set to `"postgresql"`, orchestrator uses PostgreSQL-specific discovery, failure detection, and recovery logic. See [Database Providers](database-providers.md) for details. |
 
 ### 1.2 HTTP / Network
 

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -497,3 +497,209 @@ fi
 ```
 
 For the full endpoint reference, see the [API v2 documentation](api-v2.md). An [OpenAPI 3.0 specification](api/openapi.yaml) is also available for client generation.
+
+---
+
+## Tutorial 5: Setting up orchestrator with PostgreSQL streaming replication
+
+This tutorial walks you through configuring orchestrator to manage a PostgreSQL streaming replication topology. Orchestrator discovers PostgreSQL primaries and standbys, monitors replication health, and can perform automated failover when a primary fails.
+
+### What you will need
+
+- **PostgreSQL 12+** primary with one or more streaming replication standbys already configured
+- Go 1.25+ installed (for building from source)
+- Network access from the orchestrator host to all PostgreSQL instances on port 5432
+
+### Step 1: Build orchestrator
+
+```bash
+git clone https://github.com/proxysql/orchestrator.git
+cd orchestrator
+go build -o bin/orchestrator ./go/cmd/orchestrator
+```
+
+### Step 2: Create an orchestrator user on PostgreSQL
+
+On your PostgreSQL **primary** (this user must exist on all instances -- primary and standbys):
+
+```sql
+CREATE USER orchestrator WITH PASSWORD 'orch_pass';
+GRANT pg_monitor TO orchestrator;
+```
+
+The `pg_monitor` role grants read access to `pg_stat_replication`, `pg_stat_wal_receiver`, and other monitoring views that orchestrator needs for discovery.
+
+> **Note:** If you are using PostgreSQL 9.6 (not recommended), you need to grant `SELECT` on the individual monitoring views instead of using `pg_monitor`.
+
+### Step 3: Ensure `pg_hba.conf` allows connections
+
+On each PostgreSQL instance, ensure `pg_hba.conf` allows connections from the orchestrator host:
+
+```
+# TYPE  DATABASE    USER           ADDRESS              METHOD
+host    all         orchestrator   orchestrator-host/32  md5
+```
+
+Reload PostgreSQL after editing:
+
+```bash
+psql -c "SELECT pg_reload_conf();"
+```
+
+### Step 4: Configure orchestrator for PostgreSQL
+
+Create `orchestrator.conf.json`:
+
+```json
+{
+  "Debug": true,
+  "ListenAddress": ":3000",
+  "ProviderType": "postgresql",
+  "PostgreSQLTopologyUser": "orchestrator",
+  "PostgreSQLTopologyPassword": "orch_pass",
+  "PostgreSQLSSLMode": "require",
+  "BackendDB": "sqlite",
+  "SQLite3DataFile": "/tmp/orchestrator.sqlite3",
+  "DefaultInstancePort": 5432,
+  "InstancePollSeconds": 5,
+  "RecoverMasterClusterFilters": ["*"],
+  "RecoverIntermediateMasterClusterFilters": ["*"],
+  "FailureDetectionPeriodBlockMinutes": 60,
+  "RecoveryPeriodBlockSeconds": 3600
+}
+```
+
+**Key fields explained:**
+
+| Field | Purpose |
+|-------|---------|
+| `ProviderType` | Set to `"postgresql"` to enable PostgreSQL mode. Default is `"mysql"`. |
+| `PostgreSQLTopologyUser` / `Password` | Credentials orchestrator uses to connect to your PostgreSQL instances. |
+| `PostgreSQLSSLMode` | SSL mode for PostgreSQL connections: `disable`, `require`, `verify-ca`, or `verify-full`. |
+| `DefaultInstancePort` | Set to `5432` for PostgreSQL (default is 3306 for MySQL). |
+
+### Step 5: Start orchestrator
+
+```bash
+bin/orchestrator -config orchestrator.conf.json http
+```
+
+You should see output indicating the service has started and is listening on port 3000.
+
+### Step 6: Discover your PostgreSQL topology
+
+Tell orchestrator about your PostgreSQL primary. Replace `pg-primary` with the actual hostname or IP:
+
+```bash
+curl http://localhost:3000/api/discover/pg-primary/5432
+```
+
+Expected output:
+
+```json
+{
+  "Key": {"Hostname": "pg-primary", "Port": 5432},
+  "Uptime": 1,
+  "FlavorName": "PostgreSQL",
+  "Version": "16.2",
+  "ReadOnly": false
+}
+```
+
+Orchestrator connects to the primary, queries `pg_stat_replication` to discover connected standbys, and recursively probes each standby.
+
+### Step 7: Verify discovery in the web UI
+
+Open your browser to `http://localhost:3000`. You should see your PostgreSQL replication topology visualized as a tree:
+
+- The primary node at the top (read-only: false)
+- Standby nodes underneath (read-only: true)
+- Replication lag displayed for each standby
+
+### Step 8: Verify via the API
+
+List discovered clusters:
+
+```bash
+curl -s http://localhost:3000/api/clusters
+```
+
+View the topology:
+
+```bash
+curl -s http://localhost:3000/api/topology/pg-primary/5432
+```
+
+Check replication analysis (should show `NoProblem` if everything is healthy):
+
+```bash
+curl -s http://localhost:3000/api/replication-analysis
+```
+
+Example healthy output:
+
+```json
+[]
+```
+
+An empty array means no problems detected.
+
+### Step 9: Test graceful failover
+
+To verify failover works, you can simulate a primary failure by stopping PostgreSQL on the primary:
+
+```bash
+# On the primary host:
+pg_ctl stop -D /var/lib/postgresql/16/main -m fast
+```
+
+Within a few seconds, orchestrator will detect the `DeadPrimary` condition and, if automated recovery is enabled, will:
+
+1. Select the best standby for promotion (lowest lag, most up-to-date WAL position)
+2. Call `pg_promote()` on the selected standby
+3. Reconfigure remaining standbys to replicate from the new primary via `ALTER SYSTEM SET primary_conninfo` and `pg_reload_conf()`
+
+Monitor the recovery in the web UI or via the API:
+
+```bash
+curl -s http://localhost:3000/api/replication-analysis
+```
+
+After recovery completes:
+
+```bash
+curl -s http://localhost:3000/api/topology/new-primary-host/5432
+```
+
+You should see the new primary at the top with the remaining standbys underneath.
+
+### Step 10: Verify the recovered topology
+
+Check that all standbys are replicating from the new primary:
+
+```bash
+# On the new primary:
+psql -c "SELECT client_hostname, state, sent_lsn, replay_lsn FROM pg_stat_replication;"
+```
+
+Check orchestrator's view:
+
+```bash
+curl -s http://localhost:3000/api/v2/clusters | python3 -m json.tool
+```
+
+### Differences from MySQL mode
+
+When running in PostgreSQL mode, be aware of these differences:
+
+- **No intermediate masters.** PostgreSQL streaming replication does not support cascading replication in the same way as MySQL. Orchestrator treats all standbys as direct replicas of the primary.
+- **No GTID/Pseudo-GTID.** PostgreSQL uses WAL (Write-Ahead Log) positions (LSN) instead of GTIDs. Orchestrator maps LSN to its internal binlog coordinate system.
+- **Promotion uses `pg_promote()`.** Instead of `STOP SLAVE` / `RESET SLAVE` / `CHANGE MASTER`, orchestrator calls `pg_promote()` on the standby to make it a primary.
+- **Standby reconfiguration uses `ALTER SYSTEM`.** To repoint a standby to a new primary, orchestrator updates `primary_conninfo` via `ALTER SYSTEM` and reloads the configuration.
+- **ProxySQL integration is not supported** in PostgreSQL mode. Use PgBouncer or another PostgreSQL-aware connection pooler.
+
+### Next steps
+
+- [Database providers documentation](database-providers.md) -- architecture and provider details
+- [Configuration reference](reference.md) -- all PostgreSQL-related configuration fields
+- [User manual](user-manual.md) -- PostgreSQL sections in chapters 2-5

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -181,6 +181,26 @@ Alternatively, provide credentials directly in the config (less secure):
 - **MySQL topology access**: Orchestrator must be able to reach every MySQL server it monitors on their MySQL ports.
 - **MySQL backend access** (if using MySQL backend): Orchestrator must reach its backend database.
 - **ProxySQL admin port** (default 6032): Required only if ProxySQL integration is enabled.
+- **PostgreSQL topology access** (if using PostgreSQL mode): Orchestrator must be able to reach every PostgreSQL instance on its listen port (default 5432).
+
+### PostgreSQL Prerequisites
+
+When managing PostgreSQL topologies instead of MySQL, the following prerequisites apply:
+
+- **PostgreSQL 12+** is required (for `pg_promote()` support).
+- Streaming replication must already be configured between primary and standbys.
+- All PostgreSQL instances must listen on the same port (configured via `DefaultInstancePort`).
+- The orchestrator user needs the `pg_monitor` role on all instances:
+
+```sql
+CREATE USER orchestrator WITH PASSWORD 'orch_pass';
+GRANT pg_monitor TO orchestrator;
+```
+
+- `pg_hba.conf` must allow connections from the orchestrator host on all instances.
+- Set `ProviderType` to `"postgresql"` in the orchestrator configuration.
+
+See [Tutorial 5](tutorials.md#tutorial-5-setting-up-orchestrator-with-postgresql-streaming-replication) for a complete walkthrough.
 
 ---
 
@@ -319,6 +339,33 @@ Control logging of filtered discoveries:
 }
 ```
 
+### PostgreSQL Discovery
+
+When `ProviderType` is set to `"postgresql"`, orchestrator uses a PostgreSQL-specific discovery mechanism instead of `SHOW SLAVE STATUS` / `SHOW SLAVE HOSTS`.
+
+**How PostgreSQL discovery works:**
+
+1. Orchestrator connects to a PostgreSQL instance and runs `SELECT pg_is_in_recovery()` to determine whether it is a primary or standby.
+
+2. **For a primary**, orchestrator queries:
+   - `SELECT pg_current_wal_lsn()::text` -- current WAL write position
+   - `SELECT client_hostname, client_addr, client_port FROM pg_stat_replication` -- connected standbys
+
+3. **For a standby**, orchestrator queries:
+   - `SELECT status, conninfo FROM pg_stat_wal_receiver` -- WAL receiver status and connection to the primary
+   - `SELECT pg_is_wal_replay_paused()` -- whether WAL replay is paused
+   - `SELECT pg_last_wal_replay_lsn()::text` -- current replay position
+   - `SELECT EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp())` -- replication lag in seconds
+
+4. The primary's host and port are extracted from the standby's `conninfo` field (the `primary_conninfo` connection string).
+
+**Key differences from MySQL discovery:**
+
+- Discovery does not use `SHOW SLAVE HOSTS` or `PROCESSLIST`. Instead it reads PostgreSQL system views.
+- The `client_port` in `pg_stat_replication` is an ephemeral port. Orchestrator uses `DefaultInstancePort` (set this to 5432) for all standby instance keys.
+- WAL LSN values are converted to int64 for internal storage and comparison.
+- PostgreSQL instances always report `GTIDMode: "ON"` since WAL-based replication is always position-aware.
+
 ---
 
 ## Chapter 4: Failure Detection
@@ -415,6 +462,29 @@ curl http://orchestrator:3000/api/replication-analysis
 
 # Web UI: Clusters -> Failure analysis
 ```
+
+### PostgreSQL Failure Detection
+
+When running in PostgreSQL mode (`ProviderType: "postgresql"`), orchestrator uses PostgreSQL-specific failure analysis. The analysis query reads from orchestrator's backend database (where instance data was stored during discovery) and produces analysis codes specific to PostgreSQL streaming replication.
+
+**PostgreSQL-specific analysis codes:**
+
+| Analysis Code | Condition |
+|---|---|
+| `DeadPrimary` | Primary is unreachable, standbys exist but none are replicating. This is the most common failover trigger. |
+| `DeadPrimaryAndSomeStandbys` | Primary is unreachable and either no standbys are reachable, or only some standbys are still replicating. |
+| `UnreachablePrimary` | Primary is unreachable but all standbys report they are still replicating (possible transient network issue). |
+| `AllStandbyNotReplicating` | Primary is reachable but none of its standbys are replicating. |
+| `StandbyNotReplicating` | Primary is reachable but one or more standbys are not replicating. |
+| `DeadMasterWithoutReplicas` | Primary is unreachable and has no standbys (nothing to fail over to). |
+
+**Differences from MySQL failure detection:**
+
+- No intermediate master failure types (PostgreSQL does not have intermediate masters).
+- No co-master failure types (PostgreSQL does not support multi-master replication).
+- No semi-sync related failure types.
+- No binlog server related failure types.
+- The analysis only examines `replication_depth=0` instances (primaries) and their direct standbys.
 
 ---
 
@@ -598,6 +668,35 @@ orchestrator-client -c recover -i dead.instance.com:3306
 # Force master failover regardless of orchestrator's analysis
 orchestrator-client -c force-master-failover --alias mycluster
 ```
+
+### PostgreSQL Recovery
+
+When `ProviderType` is `"postgresql"`, orchestrator performs PostgreSQL-specific recovery when a `DeadPrimary` is detected. The recovery process differs significantly from MySQL failover.
+
+**Recovery flow for a dead PostgreSQL primary:**
+
+1. **Pre-failover hooks** execute (same `PreFailoverProcesses` configuration as MySQL).
+2. **Read replicas** of the dead primary from orchestrator's backend database.
+3. **Select the best standby** for promotion. The selection criteria are:
+   - Must have a valid last check (instance was recently reachable)
+   - Must not be downtimed
+   - If a candidate key is specified and the candidate is valid, it is preferred
+   - Otherwise, the standby with the lowest replication lag and highest WAL LSN (most up-to-date) is chosen
+4. **Promote the standby** by calling `pg_promote(true, 60)` on the selected standby. Orchestrator waits up to 30 seconds for the instance to exit recovery mode.
+5. **Reconfigure remaining standbys** to replicate from the new primary:
+   - For each standby (except the promoted one), orchestrator runs `ALTER SYSTEM SET primary_conninfo = '...'` with the new primary's host, port, and credentials
+   - Then calls `pg_reload_conf()` to apply the change
+   - Pauses and resumes WAL replay to force reconnection to the new primary
+6. **Post-failover hooks** execute (`PostMasterFailoverProcesses` and `PostFailoverProcesses`).
+
+**Differences from MySQL recovery:**
+
+- No GTID/Pseudo-GTID coordination is needed. PostgreSQL standbys do not need to "catch up" to a specific binlog position before reparenting.
+- No intermediate master recovery. PostgreSQL topologies are flat (primary + standbys).
+- Promotion is a single `pg_promote()` call rather than a sequence of `STOP SLAVE` / `RESET SLAVE` / `CHANGE MASTER`.
+- Standby reconfiguration uses `ALTER SYSTEM` instead of `CHANGE MASTER TO`.
+- Standbys that fail to reconfigure are added to `LostReplicas` but do not block the recovery.
+- Graceful master takeover is not yet supported for PostgreSQL.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add **Tutorial 5** to `docs/tutorials.md`: complete walkthrough for setting up orchestrator with PostgreSQL streaming replication (user creation, configuration, discovery, failover testing, expected output at each step)
- Update **`docs/database-providers.md`**: document PostgreSQL as a fully supported provider with all supported operations, configuration fields, differences from MySQL mode, and known limitations
- Update **`docs/reference.md`**: add `ProviderType` configuration field to section 1.1 (General/Debug)
- Update **`docs/user-manual.md`**: add PostgreSQL content to Chapter 2 (prerequisites), Chapter 3 (discovery mechanism using pg_stat_replication/pg_stat_wal_receiver), Chapter 4 (PostgreSQL-specific failure analysis codes), and Chapter 5 (recovery flow with pg_promote and ALTER SYSTEM)
- Update **`README.md`**: mention PostgreSQL support in the features list and update the project description
- Update **website** (gh-pages): update features page and homepage to reflect PostgreSQL support

Closes #69

## Test plan

- [ ] Verify all documentation links resolve correctly
- [ ] Verify code examples in Tutorial 5 are consistent with the actual source code
- [ ] Verify the configuration fields documented match `go/config/config.go`
- [ ] Verify analysis codes documented match `go/inst/analysis.go`
- [ ] Review gh-pages deployment renders correctly