### PR TITLE
ci: fix lint on push/schedule and bake orchestrator test runtime image

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -55,6 +55,10 @@ jobs:
     - name: Make binary executable
       run: chmod +x bin/orchestrator
 
+    - name: Build orchestrator runtime image
+      working-directory: tests/functional
+      run: docker build -t orchestrator-runtime:latest -f orchestrator-runtime.Dockerfile .
+
     - name: Start test infrastructure (MySQL + ProxySQL)
       working-directory: tests/functional
       env:
@@ -186,6 +190,10 @@ jobs:
     - name: Make binary executable
       run: chmod +x bin/orchestrator
 
+    - name: Build orchestrator runtime image
+      working-directory: tests/functional
+      run: docker build -t orchestrator-runtime:latest -f orchestrator-runtime.Dockerfile .
+
     - name: Start PostgreSQL containers
       working-directory: tests/functional
       env:
@@ -306,6 +314,10 @@ jobs:
 
     - name: Make binary executable
       run: chmod +x bin/orchestrator
+
+    - name: Build orchestrator runtime image
+      working-directory: tests/functional
+      run: docker build -t orchestrator-runtime:latest -f orchestrator-runtime.Dockerfile .
 
     - name: Start MySQL infrastructure
       working-directory: tests/functional

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,9 @@ jobs:
         path: bin/orchestrator
 
   lint:
+    # only-new-issues needs a PR base; on push/schedule every pre-existing issue
+    # is reported as "new", so only run where the diff-vs-base comparison works.
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
 

--- a/tests/functional/docker-compose.yml
+++ b/tests/functional/docker-compose.yml
@@ -144,7 +144,7 @@ services:
           - pgstandby1
 
   orchestrator:
-    image: ubuntu:24.04
+    image: orchestrator-runtime:latest
     hostname: orchestrator
     volumes:
       - ../../bin/orchestrator:/usr/local/bin/orchestrator:ro
@@ -152,7 +152,6 @@ services:
       - ./orchestrator-test.conf.json:/orchestrator/orchestrator.conf.json:ro
     command: >
       bash -c "
-        apt-get update -qq && apt-get install -y -qq curl sqlite3 > /dev/null 2>&1 &&
         rm -f /tmp/orchestrator-test.sqlite3 &&
         cd /orchestrator &&
         orchestrator -config orchestrator.conf.json http
@@ -175,7 +174,7 @@ services:
           - orchestrator
 
   orchestrator-pg:
-    image: ubuntu:24.04
+    image: orchestrator-runtime:latest
     hostname: orchestrator-pg
     volumes:
       - ../../bin/orchestrator:/usr/local/bin/orchestrator:ro
@@ -183,7 +182,6 @@ services:
       - ./orchestrator-pg-test.conf.json:/orchestrator/orchestrator.conf.json:ro
     command: >
       bash -c "
-        apt-get update -qq && apt-get install -y -qq curl sqlite3 > /dev/null 2>&1 &&
         rm -f /tmp/orchestrator-pg-test.sqlite3 &&
         cd /orchestrator &&
         orchestrator -config orchestrator.conf.json http
@@ -206,7 +204,7 @@ services:
           - orchestrator-pg
 
   orchestrator-raft1:
-    image: ubuntu:24.04
+    image: orchestrator-runtime:latest
     hostname: orchestrator-raft1
     volumes:
       - ../../bin/orchestrator:/usr/local/bin/orchestrator:ro
@@ -214,7 +212,6 @@ services:
       - ./orchestrator-raft1.conf.json:/orchestrator/orchestrator.conf.json:ro
     command: >
       bash -c "
-        apt-get update -qq && apt-get install -y -qq curl sqlite3 > /dev/null 2>&1 &&
         mkdir -p /tmp/raft1 &&
         cd /orchestrator &&
         orchestrator -config orchestrator.conf.json http
@@ -231,7 +228,7 @@ services:
           - orchestrator-raft1
 
   orchestrator-raft2:
-    image: ubuntu:24.04
+    image: orchestrator-runtime:latest
     hostname: orchestrator-raft2
     volumes:
       - ../../bin/orchestrator:/usr/local/bin/orchestrator:ro
@@ -239,7 +236,6 @@ services:
       - ./orchestrator-raft2.conf.json:/orchestrator/orchestrator.conf.json:ro
     command: >
       bash -c "
-        apt-get update -qq && apt-get install -y -qq curl sqlite3 > /dev/null 2>&1 &&
         mkdir -p /tmp/raft2 &&
         cd /orchestrator &&
         orchestrator -config orchestrator.conf.json http
@@ -256,7 +252,7 @@ services:
           - orchestrator-raft2
 
   orchestrator-raft3:
-    image: ubuntu:24.04
+    image: orchestrator-runtime:latest
     hostname: orchestrator-raft3
     volumes:
       - ../../bin/orchestrator:/usr/local/bin/orchestrator:ro
@@ -264,7 +260,6 @@ services:
       - ./orchestrator-raft3.conf.json:/orchestrator/orchestrator.conf.json:ro
     command: >
       bash -c "
-        apt-get update -qq && apt-get install -y -qq curl sqlite3 > /dev/null 2>&1 &&
         mkdir -p /tmp/raft3 &&
         cd /orchestrator &&
         orchestrator -config orchestrator.conf.json http

--- a/tests/functional/orchestrator-runtime.Dockerfile
+++ b/tests/functional/orchestrator-runtime.Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:24.04
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl sqlite3 ca-certificates \
+ && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

- **Lint job (`main.yml`)**: gated to `pull_request` / `workflow_dispatch`. With `only-new-issues: true`, golangci-lint needs a PR base to diff against; on `push`/`schedule` every pre-existing issue is flagged as new and the job fails. Every scheduled run since April 9 has been red for this reason.
- **Functional tests**: orchestrator containers ran `apt-get update && apt-get install curl sqlite3 > /dev/null 2>&1` inside the 120s readiness window with output silenced, causing flaky "Orchestrator not ready" timeouts across the matrix (mysql 9.2/9.5/9.6, postgresql 15/17, raft). Moved the apt step into a pre-baked `orchestrator-runtime:latest` image built once per job; the orchestrator/orchestrator-pg/orchestrator-raft1..3 services now just run the binary.

Locally, orchestrator readiness drops from a 120s timeout to ~1s and the smoke suite passes 26/26.

## Test plan

- [ ] `CI` workflow green on this PR (lint compares against master base and passes)
- [ ] `Functional Tests` workflow green on this PR across the full matrix (mysql 5.7/8.0/8.4/9.0/9.2/9.5/9.6, postgresql 15/16/17, raft)
- [ ] After merge, scheduled `CI` runs stop failing on the lint job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test infrastructure by introducing a pre-built Docker image for functional tests, reducing build time and dependencies.
  * Updated continuous integration workflow to run linting checks conditionally on pull requests and manual triggers, improving workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->