### PR TITLE
ci: cache orchestrator-runtime image build via GHA cache

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -55,9 +55,18 @@ jobs:
     - name: Make binary executable
       run: chmod +x bin/orchestrator
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Build orchestrator runtime image
-      working-directory: tests/functional
-      run: docker build -t orchestrator-runtime:latest -f orchestrator-runtime.Dockerfile .
+      uses: docker/build-push-action@v6
+      with:
+        context: tests/functional
+        file: tests/functional/orchestrator-runtime.Dockerfile
+        tags: orchestrator-runtime:latest
+        load: true
+        cache-from: type=gha,scope=orchestrator-runtime
+        cache-to: type=gha,mode=max,scope=orchestrator-runtime
 
     - name: Start test infrastructure (MySQL + ProxySQL)
       working-directory: tests/functional
@@ -190,9 +199,18 @@ jobs:
     - name: Make binary executable
       run: chmod +x bin/orchestrator
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Build orchestrator runtime image
-      working-directory: tests/functional
-      run: docker build -t orchestrator-runtime:latest -f orchestrator-runtime.Dockerfile .
+      uses: docker/build-push-action@v6
+      with:
+        context: tests/functional
+        file: tests/functional/orchestrator-runtime.Dockerfile
+        tags: orchestrator-runtime:latest
+        load: true
+        cache-from: type=gha,scope=orchestrator-runtime
+        cache-to: type=gha,mode=max,scope=orchestrator-runtime
 
     - name: Start PostgreSQL containers
       working-directory: tests/functional
@@ -315,9 +333,18 @@ jobs:
     - name: Make binary executable
       run: chmod +x bin/orchestrator
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Build orchestrator runtime image
-      working-directory: tests/functional
-      run: docker build -t orchestrator-runtime:latest -f orchestrator-runtime.Dockerfile .
+      uses: docker/build-push-action@v6
+      with:
+        context: tests/functional
+        file: tests/functional/orchestrator-runtime.Dockerfile
+        tags: orchestrator-runtime:latest
+        load: true
+        cache-from: type=gha,scope=orchestrator-runtime
+        cache-to: type=gha,mode=max,scope=orchestrator-runtime
 
     - name: Start MySQL infrastructure
       working-directory: tests/functional


### PR DESCRIPTION
## Summary

- Follow-up to #96. The prior change eliminated the *silent* apt-at-runtime, but each of 12 matrix jobs still re-ran `apt-get install` on every CI run, and we already saw one PR fail when `archive.ubuntu.com` hung for 116s on a single job (exit code 100 from docker build).
- Switch the three `Build orchestrator runtime image` steps from raw `docker build` to `docker/build-push-action@v6` with `cache-from/cache-to: type=gha,scope=orchestrator-runtime`. After the first successful build, every subsequent job restores the image from the GitHub Actions cache and skips apt entirely — apt only runs again when the Dockerfile changes.

## Test plan

- [ ] First run on this PR: one job populates the GHA cache, the rest restore it (visible as "importing cache manifest"/"CACHED" lines in build logs)
- [ ] Functional Tests matrix is green
- [ ] Subsequent runs complete the image build step in seconds, not the ~20-120s apt takes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized continuous integration build process infrastructure with improved caching mechanisms and enhanced deployment capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->