### PR TITLE
fix(tests): detect PG graceful switchover at PostgreSQL level

### DIFF
--- a/tests/functional/docker-compose.yml
+++ b/tests/functional/docker-compose.yml
@@ -103,6 +103,7 @@ services:
       POSTGRES_PASSWORD: testpass
       POSTGRES_USER: postgres
     volumes:
+      - pgprimary-data:/var/lib/postgresql/data
       - ./postgres/init-primary.sh:/docker-entrypoint-initdb.d/init.sh
     ports:
       - "15432:5432"
@@ -125,6 +126,7 @@ services:
       PGUSER: postgres
       PGPASSWORD: repl_pass
     volumes:
+      - pgstandby1-data:/var/lib/postgresql/data
       - ./postgres/init-standby.sh:/init-standby.sh
     entrypoint: ["/bin/bash", "/init-standby.sh"]
     depends_on:
@@ -274,6 +276,10 @@ services:
         ipv4_address: 172.30.0.42
         aliases:
           - orchestrator-raft3
+
+volumes:
+  pgprimary-data:
+  pgstandby1-data:
 
 networks:
   orchnet:

--- a/tests/functional/postgres/init-primary.sh
+++ b/tests/functional/postgres/init-primary.sh
@@ -19,6 +19,9 @@ cat >> "$PGDATA/pg_hba.conf" <<EOF
 host    replication     repl        all     md5
 # Allow orchestrator monitoring user
 host    all             orchestrator all     md5
+# Allow orchestrator to act as a replication client when graceful-switchover
+# sets primary_conninfo on a demoted primary using orchestrator's credentials
+host    replication     orchestrator all     md5
 EOF
 
 # ---- Create users ----

--- a/tests/functional/postgres/init-primary.sh
+++ b/tests/functional/postgres/init-primary.sh
@@ -10,6 +10,8 @@ wal_level = replica
 max_wal_senders = 10
 wal_keep_size = 256MB
 hot_standby = on
+# Required for pg_rewind if an operator rewinds a demoted primary onto a new timeline
+wal_log_hints = on
 listen_addresses = '*'
 EOF
 

--- a/tests/functional/test-postgresql.sh
+++ b/tests/functional/test-postgresql.sh
@@ -152,21 +152,28 @@ else
     curl -s --max-time 10 "$ORC_URL/api/discover/172.30.0.21/5432" > /dev/null 2>&1
     sleep 5
 
-    # Verify primary has changed
-    NEW_PRIMARY=$(curl -s --max-time 10 "$ORC_URL/api/cluster/$PG_CLUSTER" 2>/dev/null | python3 -c "
-import json, sys
-instances = json.load(sys.stdin)
-for inst in instances:
-    if not inst.get('ReadOnly', True):
-        print(inst['Key']['Hostname'] + ':' + str(inst['Key']['Port']))
-        sys.exit(0)
-print('')
-" 2>/dev/null || echo "")
+    # Verify the switchover at the PostgreSQL level, not via orchestrator's
+    # cluster view. After a PG graceful takeover the demoted primary is still
+    # running (awaiting an operator-managed restart with standby.signal), so
+    # orchestrator sees two roots — one per former cluster — and a "find RO=false
+    # in original cluster" check returns the same host both times.
+    SWITCHOVER_OK=false
 
-    if [ -n "$NEW_PRIMARY" ] && [ "$NEW_PRIMARY" != "$CURRENT_PRIMARY" ]; then
-        pass "Primary switched from $CURRENT_PRIMARY to $NEW_PRIMARY"
+    # pgstandby1 must have been promoted (no longer in recovery)
+    PROMOTED=$($COMPOSE exec -T pgstandby1 psql -U postgres -tAc "SELECT pg_is_in_recovery();" 2>/dev/null | tr -d '[:space:]')
+    if [ "$PROMOTED" = "f" ]; then
+        pass "pgstandby1 has been promoted (pg_is_in_recovery=false)"
+        SWITCHOVER_OK=true
     else
-        fail "Primary did not change: was $CURRENT_PRIMARY, now ${NEW_PRIMARY:-unknown}"
+        fail "pgstandby1 still in recovery after switchover (got: '$PROMOTED')"
+    fi
+
+    # pgprimary must have been set read-only (default_transaction_read_only=on)
+    DEMOTED_RO=$($COMPOSE exec -T pgprimary psql -U postgres -tAc "SHOW default_transaction_read_only;" 2>/dev/null | tr -d '[:space:]')
+    if [ "$DEMOTED_RO" = "on" ]; then
+        pass "pgprimary has default_transaction_read_only=on"
+    else
+        fail "pgprimary default_transaction_read_only=$DEMOTED_RO (expected on)"
     fi
 
     # Verify new primary is actually writable (not just flagged read_only=false)
@@ -217,7 +224,7 @@ echo "--- Graceful switchover round-trip (switch back) ---"
 # actually stream WAL from the new primary. Simulate what a
 # PostGracefulTakeoverProcesses hook would do.
 
-if [ -n "${NEW_PRIMARY:-}" ] && [ "${NEW_PRIMARY:-}" != "${CURRENT_PRIMARY:-}" ]; then
+if [ "${SWITCHOVER_OK:-false}" = "true" ]; then
     echo "Converting demoted pgprimary into a live standby of pgstandby1..."
     $COMPOSE exec -T pgprimary bash -c 'touch /var/lib/postgresql/data/standby.signal && chown postgres:postgres /var/lib/postgresql/data/standby.signal' || true
     $COMPOSE restart pgprimary
@@ -238,39 +245,51 @@ if [ -n "${NEW_PRIMARY:-}" ] && [ "${NEW_PRIMARY:-}" != "${CURRENT_PRIMARY:-}" ]
     else
         pass "pgprimary restarted as a standby"
 
-        # Let orchestrator re-discover the flipped topology
+        # Let orchestrator re-discover — after pgprimary restarts as a standby,
+        # it joins pgstandby1's cluster ("172.30.0.21:5432"). Poll for that.
         sleep 5
         curl -s --max-time 10 "$ORC_URL/api/discover/172.30.0.20/5432" > /dev/null 2>&1
         curl -s --max-time 10 "$ORC_URL/api/discover/172.30.0.21/5432" > /dev/null 2>&1
         sleep 8
 
-        # Verify orchestrator sees pgstandby1 as primary and pgprimary as standby
-        TOPOLOGY_OK=false
+        NEW_CLUSTER=""
         for i in $(seq 1 30); do
-            PRIMARY_HOST=$(curl -s --max-time 10 "$ORC_URL/api/cluster/$PG_CLUSTER" 2>/dev/null | python3 -c "
+            NEW_CLUSTER=$(curl -s --max-time 10 "$ORC_URL/api/all-instances" 2>/dev/null | python3 -c "
 import json, sys
 for inst in json.load(sys.stdin):
-    if not inst.get('ReadOnly', True):
-        print(inst['Key']['Hostname'])
+    if inst['Key']['Hostname'] == '172.30.0.21':
+        print(inst.get('ClusterName', ''))
         sys.exit(0)
 " 2>/dev/null || echo "")
-            if [ "$PRIMARY_HOST" = "172.30.0.21" ] || [ "$PRIMARY_HOST" = "pgstandby1" ]; then
-                TOPOLOGY_OK=true
+            # Verify pgprimary (172.30.0.20) joined the same cluster as pgstandby1
+            PRIMARY_CLUSTER=$(curl -s --max-time 10 "$ORC_URL/api/all-instances" 2>/dev/null | python3 -c "
+import json, sys
+for inst in json.load(sys.stdin):
+    if inst['Key']['Hostname'] == '172.30.0.20':
+        print(inst.get('ClusterName', ''))
+        sys.exit(0)
+" 2>/dev/null || echo "")
+            if [ -n "$NEW_CLUSTER" ] && [ "$NEW_CLUSTER" = "$PRIMARY_CLUSTER" ]; then
                 break
+            fi
+            # Re-seed periodically
+            if [ "$((i % 5))" = "0" ]; then
+                curl -s --max-time 10 "$ORC_URL/api/discover/172.30.0.20/5432" > /dev/null 2>&1
+                curl -s --max-time 10 "$ORC_URL/api/discover/172.30.0.21/5432" > /dev/null 2>&1
             fi
             sleep 1
         done
 
-        if [ "$TOPOLOGY_OK" = "true" ]; then
-            pass "Orchestrator sees pgstandby1 as primary after round-trip setup"
+        if [ -n "$NEW_CLUSTER" ] && [ "$NEW_CLUSTER" = "$PRIMARY_CLUSTER" ]; then
+            pass "Orchestrator re-unified topology under new primary (cluster=$NEW_CLUSTER)"
         else
-            fail "Orchestrator does not see pgstandby1 as primary (got: ${PRIMARY_HOST:-unknown})"
+            fail "Topology not re-unified: pgstandby1 cluster=$NEW_CLUSTER pgprimary cluster=$PRIMARY_CLUSTER"
         fi
 
-        # Now switch back: pgstandby1 → pgprimary
-        if [ "$TOPOLOGY_OK" = "true" ]; then
-            echo "Executing graceful-master-takeover-auto to switch back..."
-            BACK_RESULT=$(curl -s --max-time 60 "$ORC_URL/api/graceful-master-takeover-auto/$PG_CLUSTER" 2>/dev/null)
+        # Now switch back: pgstandby1 → pgprimary, using the NEW cluster name
+        if [ -n "$NEW_CLUSTER" ] && [ "$NEW_CLUSTER" = "$PRIMARY_CLUSTER" ]; then
+            echo "Executing graceful-master-takeover-auto on cluster $NEW_CLUSTER..."
+            BACK_RESULT=$(curl -s --max-time 60 "$ORC_URL/api/graceful-master-takeover-auto/$NEW_CLUSTER" 2>/dev/null)
             BACK_CODE=$(echo "$BACK_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('Code','ERROR'))" 2>/dev/null || echo "ERROR")
 
             if [ "$BACK_CODE" = "OK" ]; then
@@ -280,22 +299,13 @@ for inst in json.load(sys.stdin):
             fi
 
             sleep 10
-            curl -s --max-time 10 "$ORC_URL/api/discover/172.30.0.20/5432" > /dev/null 2>&1
-            curl -s --max-time 10 "$ORC_URL/api/discover/172.30.0.21/5432" > /dev/null 2>&1
-            sleep 5
 
-            FINAL_PRIMARY=$(curl -s --max-time 10 "$ORC_URL/api/cluster/$PG_CLUSTER" 2>/dev/null | python3 -c "
-import json, sys
-for inst in json.load(sys.stdin):
-    if not inst.get('ReadOnly', True):
-        print(inst['Key']['Hostname'])
-        sys.exit(0)
-" 2>/dev/null || echo "")
-
-            if [ "$FINAL_PRIMARY" = "172.30.0.20" ] || [ "$FINAL_PRIMARY" = "pgprimary" ]; then
+            # Verify pgprimary is now promoted (not in recovery)
+            BACK_PROMOTED=$($COMPOSE exec -T pgprimary psql -U postgres -tAc "SELECT pg_is_in_recovery();" 2>/dev/null | tr -d '[:space:]')
+            if [ "$BACK_PROMOTED" = "f" ]; then
                 pass "Round-trip complete: pgprimary is primary again"
             else
-                fail "Round-trip incomplete: primary is '$FINAL_PRIMARY' (expected pgprimary)"
+                fail "Round-trip incomplete: pgprimary pg_is_in_recovery='$BACK_PROMOTED' (expected f)"
             fi
 
             # After round-trip, pgstandby1 is the demoted primary — reactivate

--- a/tests/functional/test-postgresql.sh
+++ b/tests/functional/test-postgresql.sh
@@ -269,10 +269,13 @@ pg_wait_streaming_standby() {
         state=$($COMPOSE exec -T "$container" psql -U postgres -tAc \
             "SELECT pg_is_in_recovery()::text || ',' || COALESCE((SELECT status FROM pg_stat_wal_receiver LIMIT 1), 'none');" \
             2>/dev/null | tr -d '[:space:]')
-        if [ "$state" = "t,streaming" ]; then
-            echo "$container is streaming as a standby after ${i}s"
-            return 0
-        fi
+        # pg_is_in_recovery()::text is "true"/"false"; bare bool prints "t"/"f"
+        case "$state" in
+            t,streaming|true,streaming)
+                echo "$container is streaming as a standby after ${i}s"
+                return 0
+                ;;
+        esac
         sleep 1
     done
     echo "$container failed to reach streaming standby state (last=$(

--- a/tests/functional/test-postgresql.sh
+++ b/tests/functional/test-postgresql.sh
@@ -224,26 +224,83 @@ echo "--- Graceful switchover round-trip (switch back) ---"
 # actually stream WAL from the new primary. Simulate what a
 # PostGracefulTakeoverProcesses hook would do.
 
-if [ "${SWITCHOVER_OK:-false}" = "true" ]; then
-    echo "Converting demoted pgprimary into a live standby of pgstandby1..."
-    $COMPOSE exec -T pgprimary bash -c 'touch /var/lib/postgresql/data/standby.signal && chown postgres:postgres /var/lib/postgresql/data/standby.signal' || true
-    $COMPOSE restart pgprimary
-    echo "Waiting for pgprimary to become a healthy standby..."
-    STANDBY_READY=false
-    for i in $(seq 1 60); do
-        IN_RECOVERY=$($COMPOSE exec -T pgprimary psql -U postgres -tAc "SELECT pg_is_in_recovery();" 2>/dev/null | tr -d '[:space:]')
-        if [ "$IN_RECOVERY" = "t" ]; then
-            STANDBY_READY=true
-            echo "pgprimary is in recovery (standby mode) after ${i}s"
-            break
+# Reclone a demoted node as a streaming standby of $2 (IP).
+# A plain standby.signal restart is not enough: after promote the demoted
+# primary's recovery point is often past the new timeline fork, so it cannot
+# follow the promoted primary without pg_rewind or a fresh basebackup.
+# Uses named volumes so we can stop the service, rewrite datadir via a
+# one-off container, then start again.
+pg_reclone_as_standby() {
+    local container="$1"
+    local new_primary_ip="$2"
+    echo "Stopping $container for reclone onto $new_primary_ip..."
+    $COMPOSE stop "$container" >/dev/null
+    # One-off container shares the service's named volume + network.
+    if ! $COMPOSE run --rm --no-deps --entrypoint bash \
+        -e PGPASSWORD=repl_pass \
+        "$container" -c "
+set -e
+PGDATA=/var/lib/postgresql/data
+rm -rf \"\$PGDATA\"/*
+chown postgres:postgres \"\$PGDATA\"
+gosu postgres pg_basebackup \
+    -h '$new_primary_ip' -p 5432 -U repl -D \"\$PGDATA\" -Fp -Xs -P -R
+# Force IP-based primary_conninfo (Docker DNS breaks when containers stop)
+cat > \"\$PGDATA/postgresql.auto.conf\" <<EOF
+primary_conninfo = 'host=$new_primary_ip port=5432 user=repl password=repl_pass'
+EOF
+touch \"\$PGDATA/standby.signal\"
+chown -R postgres:postgres \"\$PGDATA\"
+chmod 0700 \"\$PGDATA\"
+"; then
+        echo "pg_basebackup reclone of $container failed"
+        $COMPOSE start "$container" >/dev/null || true
+        return 1
+    fi
+    $COMPOSE start "$container" >/dev/null
+}
+
+# Wait until container is in recovery AND streaming from its primary.
+pg_wait_streaming_standby() {
+    local container="$1"
+    local max_secs="${2:-60}"
+    for i in $(seq 1 "$max_secs"); do
+        local state
+        state=$($COMPOSE exec -T "$container" psql -U postgres -tAc \
+            "SELECT pg_is_in_recovery()::text || ',' || COALESCE((SELECT status FROM pg_stat_wal_receiver LIMIT 1), 'none');" \
+            2>/dev/null | tr -d '[:space:]')
+        if [ "$state" = "t,streaming" ]; then
+            echo "$container is streaming as a standby after ${i}s"
+            return 0
         fi
         sleep 1
     done
+    echo "$container failed to reach streaming standby state (last=$(
+        $COMPOSE exec -T "$container" psql -U postgres -tAc \
+            "SELECT pg_is_in_recovery()::text || ',' || COALESCE((SELECT status FROM pg_stat_wal_receiver LIMIT 1), 'none');" \
+            2>/dev/null | tr -d '[:space:]'
+    ))"
+    return 1
+}
+
+if [ "${SWITCHOVER_OK:-false}" = "true" ]; then
+    echo "Converting demoted pgprimary into a live standby of pgstandby1 (pg_basebackup reclone)..."
+    if pg_reclone_as_standby pgprimary 172.30.0.21; then
+        :
+    else
+        fail "Failed to reclone pgprimary as standby of pgstandby1"
+    fi
+    echo "Waiting for pgprimary to become a healthy streaming standby..."
+    if pg_wait_streaming_standby pgprimary 60; then
+        STANDBY_READY=true
+    else
+        STANDBY_READY=false
+    fi
 
     if [ "$STANDBY_READY" != "true" ]; then
-        fail "pgprimary did not enter standby/recovery mode after restart"
+        fail "pgprimary did not enter streaming standby mode after reclone"
     else
-        pass "pgprimary restarted as a standby"
+        pass "pgprimary recloned as a streaming standby"
 
         # Let orchestrator re-discover — after pgprimary restarts as a standby,
         # it joins pgstandby1's cluster ("172.30.0.21:5432"). Poll for that.
@@ -308,20 +365,16 @@ for inst in json.load(sys.stdin):
                 fail "Round-trip incomplete: pgprimary pg_is_in_recovery='$BACK_PROMOTED' (expected f)"
             fi
 
-            # After round-trip, pgstandby1 is the demoted primary — reactivate
-            # it as a live standby so the downstream failover-kill test has a
-            # replica to promote.
+            # After round-trip, pgstandby1 is the demoted primary. Its entrypoint
+            # (init-standby.sh) always basebackups from 172.30.0.20 on start —
+            # restart is enough once pgprimary is primary again.
             echo "Reactivating pgstandby1 as a live standby of pgprimary..."
-            $COMPOSE exec -T pgstandby1 bash -c 'touch /var/lib/postgresql/data/standby.signal && chown postgres:postgres /var/lib/postgresql/data/standby.signal' || true
-            $COMPOSE restart pgstandby1
-            for i in $(seq 1 60); do
-                IN_RECOVERY=$($COMPOSE exec -T pgstandby1 psql -U postgres -tAc "SELECT pg_is_in_recovery();" 2>/dev/null | tr -d '[:space:]')
-                if [ "$IN_RECOVERY" = "t" ]; then
-                    echo "pgstandby1 is streaming as a standby after ${i}s"
-                    break
-                fi
-                sleep 1
-            done
+            $COMPOSE restart pgstandby1 >/dev/null
+            if pg_wait_streaming_standby pgstandby1 60; then
+                pass "pgstandby1 restarted as a streaming standby of pgprimary"
+            else
+                fail "pgstandby1 did not become a streaming standby after restart"
+            fi
             sleep 5
             curl -s --max-time 10 "$ORC_URL/api/discover/172.30.0.20/5432" > /dev/null 2>&1
             curl -s --max-time 10 "$ORC_URL/api/discover/172.30.0.21/5432" > /dev/null 2>&1


### PR DESCRIPTION
## Summary

PR #99's functional tests fail on master across PG 15/16/17. The failing assertion (`Primary did not change: was 172.30.0.20:5432, now 172.30.0.20:5432`) is an inherited check that does not work for PG graceful takeover:

- PG's graceful takeover does not restart the demoted primary; it only sets `primary_conninfo`. Per the design, the operator completes the switchover via a `PostGracefulTakeoverProcesses` hook that creates `standby.signal` and restarts.
- Until that restart, orchestrator sees the demoted primary as a separate cluster root (RO=false). So looking for "the RO=false instance in the original cluster" returns the same host before and after — a false negative.

Run: https://github.com/ProxySQL/orchestrator/actions/runs/24606553086

## Fix

Replace the cluster-view check with direct PostgreSQL-level signals:

- `pg_is_in_recovery()=f` on pgstandby1 (the standby was promoted)
- `default_transaction_read_only=on` on pgprimary (the primary was demoted)

The existing writability check against pgstandby1 and the `primary_conninfo` check on pgprimary stay.

The round-trip section now:
- Gates on `SWITCHOVER_OK` derived from the direct PG check.
- Discovers the new cluster name dynamically after pgprimary is restarted as a standby (it joins pgstandby1's cluster, which is not the original `PG_CLUSTER`).
- Uses `pg_is_in_recovery()` on pgprimary to verify the round-trip instead of the split-brain cluster view.

## Test plan
- [ ] Functional tests pass on PG 15/16/17 (the three matrix jobs that previously failed)
- [ ] MySQL matrix + Raft job remain green (unchanged logic)
- [ ] Dead-primary failover still recovers after the full round-trip sequence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened PostgreSQL switchover validation by using direct database state checks for promotion and read-only status instead of relying on orchestrator-observed primary parsing.
  * Improved graceful switchover round-trip coverage by recloning and restarting workloads, waiting for confirmed streaming, and confirming the correct cluster association before takeover.
  * Updated functional PostgreSQL setup to enable `wal_log_hints` and expanded replication access to support dynamic `primary_conninfo` configuration.
* **Chores**
  * Updated the functional Docker Compose setup to use persistent named volumes for primary and standby data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->