### PR TITLE
Fix web UI: register yield FuncMap when rendering layout

### DIFF
--- a/go/http/render.go
+++ b/go/http/render.go
@@ -17,6 +17,7 @@
 package http
 
 import (
+	"bytes"
 	"encoding/json"
 	"html/template"
 	"net/http"
@@ -35,50 +36,77 @@ func renderJSON(w http.ResponseWriter, status int, data interface{}) {
 	}
 }
 
-// templateCache caches parsed templates.
-var templateCache = struct {
+// templateDir is a var (not a const) so tests can point it at a temp dir.
+var templateDir = "resources"
+
+const layoutFile = "templates/layout"
+
+// innerTemplateCache caches parsed inner (non-layout) templates. Inner
+// templates have no per-request state so caching is safe. The layout, by
+// contrast, is re-parsed per request because its FuncMap closes over a
+// per-request buffer (see renderHTML).
+var innerTemplateCache = struct {
 	sync.RWMutex
 	m map[string]*template.Template
 }{m: make(map[string]*template.Template)}
 
-const templateDir = "resources"
-const layoutFile = "templates/layout"
-
-// getTemplate returns a cached template or parses and caches it.
-func getTemplate(name string) (*template.Template, error) {
-	templateCache.RLock()
-	if t, ok := templateCache.m[name]; ok {
-		templateCache.RUnlock()
+// getInnerTemplate returns a cached inner template or parses and caches it.
+func getInnerTemplate(name string) (*template.Template, error) {
+	innerTemplateCache.RLock()
+	if t, ok := innerTemplateCache.m[name]; ok {
+		innerTemplateCache.RUnlock()
 		return t, nil
 	}
-	templateCache.RUnlock()
+	innerTemplateCache.RUnlock()
 
-	layoutPath := filepath.Join(templateDir, layoutFile+".tmpl")
 	tmplPath := filepath.Join(templateDir, name+".tmpl")
-	t, err := template.ParseFiles(layoutPath, tmplPath)
+	t, err := template.ParseFiles(tmplPath)
 	if err != nil {
 		return nil, err
 	}
 
-	templateCache.Lock()
-	templateCache.m[name] = t
-	templateCache.Unlock()
+	innerTemplateCache.Lock()
+	innerTemplateCache.m[name] = t
+	innerTemplateCache.Unlock()
 	return t, nil
 }
 
-// renderHTML renders an HTML template with the given data.
-// The template name should be like "templates/clusters".
+// renderHTML renders an HTML template within the layout. The template name
+// should be like "templates/clusters". The layout
+// (resources/templates/layout.tmpl) uses {{yield}} to inject the inner
+// template's rendered output, supplied by the FuncMap below.
 func renderHTML(w http.ResponseWriter, status int, name string, data interface{}) {
-	t, err := getTemplate(name)
+	inner, err := getInnerTemplate(name)
 	if err != nil {
 		_ = log.Errorf("Error parsing template %s: %+v", name, err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
+
+	var innerBuf bytes.Buffer
+	if err := inner.Execute(&innerBuf, data); err != nil {
+		_ = log.Errorf("Error executing inner template %s: %+v", name, err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	layoutPath := filepath.Join(templateDir, layoutFile+".tmpl")
+	// The FuncMap must be registered on a template whose name matches the one
+	// ParseFiles assigns (the file's basename), otherwise Execute fails with
+	// "template ... is undefined".
+	layout, err := template.New(filepath.Base(layoutPath)).Funcs(template.FuncMap{
+		"yield": func() template.HTML { return template.HTML(innerBuf.String()) },
+	}).ParseFiles(layoutPath)
+	if err != nil {
+		_ = log.Errorf("Error parsing layout for %s: %+v", name, err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
 	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	w.WriteHeader(status)
-	if err := t.Execute(w, data); err != nil {
-		_ = log.Errorf("Error executing template %s: %+v", name, err)
+	if err := layout.Execute(w, data); err != nil {
+		_ = log.Errorf("Error executing layout for %s: %+v", name, err)
 	}
 }
 

--- a/go/http/render_test.go
+++ b/go/http/render_test.go
@@ -1,0 +1,68 @@
+/*
+   Copyright 2014 Outbrain Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package http
+
+import (
+	"html/template"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRenderHTML_YieldInjectsInnerContent guards against regressions in the
+// layout/inner template composition: layout.tmpl uses {{yield}} to inject the
+// inner template's rendered output, and dropping the yield FuncMap (as
+// happened when this fork rewrote rendering to use stdlib html/template)
+// causes every /web/* page to 500.
+func TestRenderHTML_YieldInjectsInnerContent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "templates"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	layout := `<!doctype html><html><body><header>CHROME</header>{{yield}}<footer>FOOT</footer></body></html>`
+	inner := `<main>HELLO {{.Name}}</main>`
+	if err := os.WriteFile(filepath.Join(dir, "templates", "layout.tmpl"), []byte(layout), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "templates", "page.tmpl"), []byte(inner), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := templateDir
+	templateDir = dir
+	t.Cleanup(func() {
+		templateDir = orig
+		innerTemplateCache.Lock()
+		innerTemplateCache.m = map[string]*template.Template{}
+		innerTemplateCache.Unlock()
+	})
+
+	rec := httptest.NewRecorder()
+	renderHTML(rec, 200, "templates/page", map[string]string{"Name": "world"})
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"CHROME", "HELLO world", "FOOT"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q\nbody: %s", want, body)
+		}
+	}
+}


### PR DESCRIPTION
Every /web/* route returned 500 with 'template: layout.tmpl:133: function "yield" not defined' because go/http/render.go was rewritten to use Go stdlib html/template directly without porting the yield helper that martini-contrib/render provided in the upstream openark codebase, while resources/templates/layout.tmpl still expects {{yield}} to inject the inner template's rendered content.

Render the inner template to a buffer first, then parse the layout with a FuncMap whose yield() returns template.HTML(buf.String()). The layout must be re-parsed per request because its FuncMap closes over the per-request buffer; the inner template is cached as before since it has no per-request state. Layout parse cost is negligible (~150-line file) relative to backend MySQL queries.

Adds a regression test in go/http/render_test.go that exercises a temp-dir resources/ tree to assert layout+inner composition keeps working.

## Pull Request

Related issue: https://github.com/proxysql/orchestrator/issues/

### Description

This PR [briefly explain what it does]

### Checklist

Please review the [contribution guidelines](CONTRIBUTING.md) before submitting.

- [ ] Code formatted with `gofmt` (please avoid `goimports`)
- [ ] Tests added/updated
- [ ] CI passes (unit, integration, system tests)
- [ ] DCO sign-off included (`git commit -s`)
- [ ] Related issue linked above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved HTML template rendering and caching mechanism for better performance.
  * Enhanced template configuration flexibility to better support testing environments.

* **Tests**
  * Added regression test to verify template rendering with dynamic content injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->