### PR TITLE
Add (raft) health related metrics to prometheus exporter and fix some existing ones

### DIFF
--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -132,6 +132,14 @@ func init() {
 				ometrics.ActiveTopologyIssues.WithLabelValues(issueType).Set(float64(count))
 			}
 		}
+		if clusters, err := inst.ReadClustersInfo(""); err == nil {
+			ometrics.ClustersTotal.Set(float64(len(clusters)))
+			var instancesTotal uint
+			for _, c := range clusters {
+				instancesTotal += c.CountInstances
+			}
+			ometrics.InstancesTotal.Set(float64(instancesTotal))
+		}
 	})
 }
 

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -91,6 +91,7 @@ func init() {
 
 	ometrics.OnMetricsTick(func() {
 		discoveryQueueLengthGauge.Update(int64(discoveryQueue.QueueLen()))
+		ometrics.DiscoveryQueueLength.Set(float64(discoveryQueue.QueueLen()))
 	})
 	ometrics.OnMetricsTick(func() {
 		if recentDiscoveryOperationKeys == nil {
@@ -113,6 +114,24 @@ func init() {
 	})
 	ometrics.OnMetricsTick(func() {
 		isRaftLeaderGauge.Update(atomic.LoadInt64(&isElectedNode))
+	})
+	ometrics.OnMetricsTick(func() {
+		if instances, err := inst.ReadDowntimedInstances(""); err == nil {
+			ometrics.DowntimedInstances.Set(float64(len(instances)))
+		}
+		if recoveries, err := ReadActiveRecoveries(); err == nil {
+			ometrics.ActiveRecoveries.Set(float64(len(recoveries)))
+		}
+		if analysis, err := inst.GetReplicationAnalysis("", &inst.ReplicationAnalysisHints{}); err == nil {
+			issuesCount := make(map[string]int)
+			for _, a := range analysis {
+				issuesCount[string(a.Analysis)]++
+			}
+			ometrics.ActiveTopologyIssues.Reset()
+			for issueType, count := range issuesCount {
+				ometrics.ActiveTopologyIssues.WithLabelValues(issueType).Set(float64(count))
+			}
+		}
 	})
 }
 
@@ -192,6 +211,7 @@ func handleDiscoveryRequests() {
 		_ = metrics.Register("discoveries.dead_instances_queue_length", deadInstancesDiscoveryQueueLengthGauge)
 		ometrics.OnMetricsTick(func() {
 			deadInstancesDiscoveryQueueLengthGauge.Update(int64(deadInstancesDiscoveryQueue.QueueLen()))
+			ometrics.DeadInstancesDiscoveryQueueLength.Set(float64(deadInstancesDiscoveryQueue.QueueLen()))
 		})
 
 		// create a pool of discovery workers

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -90,8 +90,10 @@ func init() {
 	_ = metrics.Register("raft.is_leader", isRaftLeaderGauge)
 
 	ometrics.OnMetricsTick(func() {
-		discoveryQueueLengthGauge.Update(int64(discoveryQueue.QueueLen()))
-		ometrics.DiscoveryQueueLength.Set(float64(discoveryQueue.QueueLen()))
+		if discoveryQueue != nil {
+			discoveryQueueLengthGauge.Update(int64(discoveryQueue.QueueLen()))
+			ometrics.DiscoveryQueueLength.Set(float64(discoveryQueue.QueueLen()))
+		}
 	})
 	ometrics.OnMetricsTick(func() {
 		if recentDiscoveryOperationKeys == nil {
@@ -115,34 +117,9 @@ func init() {
 	ometrics.OnMetricsTick(func() {
 		isRaftLeaderGauge.Update(atomic.LoadInt64(&isElectedNode))
 	})
-	ometrics.OnMetricsTick(func() {
-		if instances, err := inst.ReadDowntimedInstances(""); err == nil {
-			ometrics.DowntimedInstances.Set(float64(len(instances)))
-		}
-		if recoveries, err := ReadActiveRecoveries(); err == nil {
-			ometrics.ActiveRecoveries.Set(float64(len(recoveries)))
-		}
-		if analysis, err := inst.GetReplicationAnalysis("", &inst.ReplicationAnalysisHints{}); err == nil {
-			issuesCount := make(map[string]int)
-			for _, a := range analysis {
-				issuesCount[string(a.Analysis)]++
-			}
-			ometrics.ActiveTopologyIssues.Reset()
-			for issueType, count := range issuesCount {
-				ometrics.ActiveTopologyIssues.WithLabelValues(issueType).Set(float64(count))
-			}
-		}
-		if clusters, err := inst.ReadClustersInfo(""); err == nil {
-			ometrics.ClustersTotal.Set(float64(len(clusters)))
-			var instancesTotal uint
-			for _, c := range clusters {
-				instancesTotal += c.CountInstances
-			}
-			ometrics.InstancesTotal.Set(float64(instancesTotal))
-		}
-	})
 }
 
+// IsLeader returns true if the current orchestrator instance is the cluster leader.
 func IsLeader() bool {
 	if orcraft.IsRaftEnabled() {
 		return orcraft.IsLeader()
@@ -150,6 +127,8 @@ func IsLeader() bool {
 	return atomic.LoadInt64(&isElectedNode) == 1
 }
 
+// IsLeaderOrActive returns true if the current orchestrator instance is either the cluster leader
+// or an active member (when Raft is enabled, returns true if part of quorum).
 func IsLeaderOrActive() bool {
 	if orcraft.IsRaftEnabled() {
 		return orcraft.IsPartOfQuorum()
@@ -611,6 +590,7 @@ func ContinuousDiscovery() {
 	raftCaretakingTick := time.Tick(10 * time.Minute)
 	recoveryTick := time.Tick(time.Duration(config.RecoveryPollSeconds) * time.Second)
 	autoPseudoGTIDTick := time.Tick(time.Duration(config.PseudoGTIDIntervalSeconds) * time.Second)
+	dbMetricsTick := time.Tick(30 * time.Second)
 	var recoveryEntrance int64
 	var snapshotTopologiesTick <-chan time.Time
 	if config.Config.SnapshotTopologiesIntervalHours > 0 {
@@ -642,6 +622,33 @@ func ContinuousDiscovery() {
 	log.Infof("continuous discovery: starting")
 	for {
 		select {
+		case <-dbMetricsTick:
+			go func() {
+				if instances, err := inst.ReadDowntimedInstances(""); err == nil {
+					ometrics.DowntimedInstances.Set(float64(len(instances)))
+				}
+				if recoveries, err := ReadActiveRecoveries(); err == nil {
+					ometrics.ActiveRecoveries.Set(float64(len(recoveries)))
+				}
+				if analysis, err := inst.GetReplicationAnalysis("", &inst.ReplicationAnalysisHints{}); err == nil {
+					issuesCount := make(map[string]int)
+					for _, a := range analysis {
+						issuesCount[string(a.Analysis)]++
+					}
+					ometrics.ActiveTopologyIssues.Reset()
+					for issueType, count := range issuesCount {
+						ometrics.ActiveTopologyIssues.WithLabelValues(issueType).Set(float64(count))
+					}
+				}
+				if clusters, err := inst.ReadClustersInfo(""); err == nil {
+					ometrics.ClustersTotal.Set(float64(len(clusters)))
+					var instancesTotal uint
+					for _, c := range clusters {
+						instancesTotal += c.CountInstances
+					}
+					ometrics.InstancesTotal.Set(float64(instancesTotal))
+				}
+			}()
 		case <-healthTick:
 			go func() {
 				onHealthTick()

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -91,8 +91,9 @@ func init() {
 
 	ometrics.OnMetricsTick(func() {
 		if discoveryQueue != nil {
-			discoveryQueueLengthGauge.Update(int64(discoveryQueue.QueueLen()))
-			ometrics.DiscoveryQueueLength.Set(float64(discoveryQueue.QueueLen()))
+			queueLen := discoveryQueue.QueueLen()
+			discoveryQueueLengthGauge.Update(int64(queueLen))
+			ometrics.DiscoveryQueueLength.Set(float64(queueLen))
 		}
 	})
 	ometrics.OnMetricsTick(func() {

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -298,6 +298,7 @@ func DiscoverInstance(instanceKey inst.InstanceKey) {
 	}
 
 	discoveriesCounter.Inc(1)
+	ometrics.DiscoveriesTotal.Inc()
 
 	// First we've ever heard of this instance. Continue investigation:
 	var err error
@@ -318,6 +319,7 @@ func DiscoverInstance(instanceKey inst.InstanceKey) {
 
 	if instance == nil {
 		failedDiscoveriesCounter.Inc(1)
+		ometrics.DiscoveryErrorsTotal.Inc()
 		_ = discoveryMetrics.Append(&discovery.Metric{
 			Timestamp:       time.Now(),
 			InstanceKey:     instanceKey,

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1895,7 +1895,20 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 	if isActionableRecovery || util.ClearToLog("executeCheckAndRecoverFunction: recovery", analysisEntry.AnalyzedInstanceKey.StringCode()) {
 		log.Infof("executeCheckAndRecoverFunction: proceeding with %+v recovery on %+v; isRecoverable?: %+v; skipProcesses: %+v", analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey, isActionableRecovery, skipProcesses)
 	}
+	startTime := time.Now()
 	recoveryAttempted, topologyRecovery, err = checkAndRecoverFunction(analysisEntry, candidateInstanceKey, forceInstanceRecovery, skipProcesses)
+
+	if recoveryAttempted && topologyRecovery != nil {
+		duration := time.Since(startTime).Seconds()
+		ometrics.RecoveryDurationSeconds.Observe(duration)
+
+		result := "success"
+		if !topologyRecovery.IsSuccessful {
+			result = "failed"
+		}
+		ometrics.RecoveriesTotal.WithLabelValues(string(analysisEntry.Analysis), result).Inc()
+	}
+
 	if !recoveryAttempted {
 		return recoveryAttempted, topologyRecovery, err
 	}

--- a/go/metrics/prometheus.go
+++ b/go/metrics/prometheus.go
@@ -95,6 +95,53 @@ var (
 		}
 		return 0
 	})
+
+	DiscoveryQueueLength = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "orchestrator_discovery_queue_length",
+		Help: "Length of the discovery queue.",
+	})
+
+	DeadInstancesDiscoveryQueueLength = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "orchestrator_dead_instances_discovery_queue_length",
+		Help: "Length of the dead instances discovery queue.",
+	})
+
+	ActiveRecoveries = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "orchestrator_active_recoveries",
+		Help: "Number of active (in-progress) recoveries.",
+	})
+
+	DowntimedInstances = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "orchestrator_downtimed_instances_total",
+		Help: "Number of instances currently marked as downtimed.",
+	})
+
+	ActiveTopologyIssues = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "orchestrator_active_topology_issues",
+		Help: "Number of active topology issues, broken down by issue type.",
+	}, []string{"issue_type"})
+
+	RaftPeersTotal = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "orchestrator_raft_peers_total",
+		Help: "Number of known raft peers.",
+	}, func() float64 {
+		if orcraft.IsRaftEnabled() {
+			if peers, err := orcraft.GetPeers(); err == nil {
+				return float64(len(peers))
+			}
+		}
+		return 0
+	})
+
+	RaftIsPartOfQuorum = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "orchestrator_raft_is_part_of_quorum",
+		Help: "1 if the node is part of raft quorum, 0 otherwise.",
+	}, func() float64 {
+		if orcraft.IsRaftEnabled() && orcraft.IsPartOfQuorum() {
+			return 1
+		}
+		return 0
+	})
 )
 
 // InitPrometheus registers all Prometheus metrics. Should be called once at
@@ -115,5 +162,12 @@ func InitPrometheus() {
 		HealthIsLive,
 		RaftIsHealthy,
 		RaftIsLeader,
+		DiscoveryQueueLength,
+		DeadInstancesDiscoveryQueueLength,
+		ActiveRecoveries,
+		DowntimedInstances,
+		ActiveTopologyIssues,
+		RaftPeersTotal,
+		RaftIsPartOfQuorum,
 	)
 }

--- a/go/metrics/prometheus.go
+++ b/go/metrics/prometheus.go
@@ -17,9 +17,13 @@
 package metrics
 
 import (
+	"sync/atomic"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/proxysql/golib/log"
 	"github.com/proxysql/orchestrator/go/config"
+	"github.com/proxysql/orchestrator/go/process"
+	orcraft "github.com/proxysql/orchestrator/go/raft"
 )
 
 // Prometheus metric variables, exported so other packages can update them.
@@ -54,6 +58,43 @@ var (
 		Help:    "Duration of recovery operations in seconds.",
 		Buckets: prometheus.ExponentialBuckets(0.5, 2, 12), // 0.5s to ~1024s
 	})
+
+	HealthIsReady = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "orchestrator_health_is_ready",
+		Help: "1 if the node is ready, 0 otherwise.",
+	}, func() float64 {
+		if atomic.LoadInt64(&process.LastContinousCheckHealthy) == 1 {
+			return 1
+		}
+		return 0
+	})
+
+	HealthIsLive = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "orchestrator_health_is_live",
+		Help: "1 if the node is live, 0 otherwise.",
+	}, func() float64 {
+		return 1
+	})
+
+	RaftIsHealthy = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "orchestrator_raft_is_healthy",
+		Help: "1 if the node is a healthy raft node, 0 otherwise.",
+	}, func() float64 {
+		if orcraft.IsRaftEnabled() && orcraft.IsHealthy() {
+			return 1
+		}
+		return 0
+	})
+
+	RaftIsLeader = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "orchestrator_raft_is_leader",
+		Help: "1 if the node is the raft leader, 0 otherwise.",
+	}, func() float64 {
+		if orcraft.IsRaftEnabled() && orcraft.IsLeader() {
+			return 1
+		}
+		return 0
+	})
 )
 
 // InitPrometheus registers all Prometheus metrics. Should be called once at
@@ -70,5 +111,9 @@ func InitPrometheus() {
 		ClustersTotal,
 		RecoveriesTotal,
 		RecoveryDurationSeconds,
+		HealthIsReady,
+		HealthIsLive,
+		RaftIsHealthy,
+		RaftIsLeader,
 	)
 }


### PR DESCRIPTION
## Pull Request

Related issue: https://github.com/proxysql/orchestrator/issues/

### Description

This PR adds a couple of health related metrics, very useful for monitoring using a Prometheus (compatible) stack.

- `orchestrator_health_is_ready`
- `orchestrator_health_is_live`

And for Raft enabled clusters

- `orchestrator_raft_is_healthy`
- `orchestrator_raft_is_leader`
- `orchestrator_raft_peers_total`
- `orchestrator_raft_is_part_of_quorum`

Extra metrics around orchestrator performance and  infrastructure state

- `orchestrator_discovery_queue_length`
- `orchestrator_dead_instances_discovery_queue_length`
- `orchestrator_active_recoveries`
- `orchestrator_downtimed_instances_total`
- `orchestrator_active_topology_issues`

Fixes a couple of existing metrics that were not reporting properly

- `orchestrator_clusters_total`
- `orchestrator_instances_total`
- `orchestrator_discoveries_total`
- `orchestrator_discovery_errors_total`
- `orchestrator_recoveries_total`
- `orchestrator_recovery_duration_seconds`

Example output
```
curl -s http://localhost:3000/metrics
# HELP go_gc_duration_seconds A summary of the wall-time pause (stop-the-world) duration in garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 3.2422e-05
go_gc_duration_seconds{quantile="0.25"} 0.000151474
go_gc_duration_seconds{quantile="0.5"} 0.000246696
go_gc_duration_seconds{quantile="0.75"} 0.000340244
go_gc_duration_seconds{quantile="1"} 0.000340244
go_gc_duration_seconds_sum 0.000770836
go_gc_duration_seconds_count 4
# HELP go_gc_gogc_percent Heap size target percentage configured by the user, otherwise 100. This value is set by the GOGC environment variable, and the runtime/debug.SetGCPercent function. Sourced from /gc/gogc:percent.
# TYPE go_gc_gogc_percent gauge
go_gc_gogc_percent 100
# HELP go_gc_gomemlimit_bytes Go runtime memory limit configured by the user, otherwise math.MaxInt64. This value is set by the GOMEMLIMIT environment variable, and the runtime/debug.SetMemoryLimit function. Sourced from /gc/gomemlimit:bytes.
# TYPE go_gc_gomemlimit_bytes gauge
go_gc_gomemlimit_bytes 9.223372036854776e+18
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 357
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.26.3"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated in heap and currently in use. Equals to /memory/classes/heap/objects:bytes.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 4.545432e+06
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated in heap until now, even if released already. Equals to /gc/heap/allocs:bytes.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 1.1865984e+07
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table. Equals to /memory/classes/profiling/buckets:bytes.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 1.452245e+06
# HELP go_memstats_frees_total Total number of heap objects frees. Equals to /gc/heap/frees:objects + /gc/heap/tiny/allocs:objects.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 77864
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata. Equals to /memory/classes/metadata/other:bytes.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 3.162352e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and currently in use, same as go_memstats_alloc_bytes. Equals to /memory/classes/heap/objects:bytes.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 4.545432e+06
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used. Equals to /memory/classes/heap/released:bytes + /memory/classes/heap/free:bytes.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 4.980736e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use. Equals to /memory/classes/heap/objects:bytes + /memory/classes/heap/unused:bytes
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 6.258688e+06
# HELP go_memstats_heap_objects Number of currently allocated objects. Equals to /gc/heap/objects:objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 10907
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS. Equals to /memory/classes/heap/released:bytes.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 2.613248e+06
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system. Equals to /memory/classes/heap/objects:bytes + /memory/classes/heap/unused:bytes + /memory/classes/heap/released:bytes + /memory/classes/heap/free:bytes.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 1.1239424e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.779879193451239e+09
# HELP go_memstats_mallocs_total Total number of heap objects allocated, both live and gc-ed. Semantically a counter version for go_memstats_heap_objects gauge. Equals to /gc/heap/allocs:objects + /gc/heap/tiny/allocs:objects.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 88771
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures. Equals to /memory/classes/metadata/mcache/inuse:bytes.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 4592
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system. Equals to /memory/classes/metadata/mcache/inuse:bytes + /memory/classes/metadata/mcache/free:bytes.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 16072
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures. Equals to /memory/classes/metadata/mspan/inuse:bytes.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 86560
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system. Equals to /memory/classes/metadata/mspan/inuse:bytes + /memory/classes/metadata/mspan/free:bytes.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 97920
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place. Equals to /gc/heap/goal:bytes.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 9.46697e+06
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations. Equals to /memory/classes/other:bytes.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 619003
# HELP go_memstats_stack_inuse_bytes Number of bytes obtained from system for stack allocator in non-CGO environments. Equals to /memory/classes/heap/stacks:bytes.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 1.343488e+06
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator. Equals to /memory/classes/heap/stacks:bytes + /memory/classes/os-stacks:bytes.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 1.343488e+06
# HELP go_memstats_sys_bytes Number of bytes obtained from system. Equals to /memory/classes/total:byte.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 1.7930504e+07
# HELP go_sched_gomaxprocs_threads The current runtime.GOMAXPROCS setting, or the number of operating system threads that can execute user-level Go code simultaneously. Sourced from /sched/gomaxprocs:threads.
# TYPE go_sched_gomaxprocs_threads gauge
go_sched_gomaxprocs_threads 2
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 9
# HELP orchestrator_active_recoveries Number of active (in-progress) recoveries.
# TYPE orchestrator_active_recoveries gauge
orchestrator_active_recoveries 0
# HELP orchestrator_clusters_total Total number of known clusters.
# TYPE orchestrator_clusters_total gauge
orchestrator_clusters_total 0
# HELP orchestrator_dead_instances_discovery_queue_length Length of the dead instances discovery queue.
# TYPE orchestrator_dead_instances_discovery_queue_length gauge
orchestrator_dead_instances_discovery_queue_length 0
# HELP orchestrator_discoveries_total Total number of discovery attempts.
# TYPE orchestrator_discoveries_total counter
orchestrator_discoveries_total 0
# HELP orchestrator_discovery_errors_total Total number of failed discoveries.
# TYPE orchestrator_discovery_errors_total counter
orchestrator_discovery_errors_total 0
# HELP orchestrator_discovery_queue_length Length of the discovery queue.
# TYPE orchestrator_discovery_queue_length gauge
orchestrator_discovery_queue_length 0
# HELP orchestrator_downtimed_instances_total Number of instances currently marked as downtimed.
# TYPE orchestrator_downtimed_instances_total gauge
orchestrator_downtimed_instances_total 0
# HELP orchestrator_health_is_live 1 if the node is live, 0 otherwise.
# TYPE orchestrator_health_is_live gauge
orchestrator_health_is_live 1
# HELP orchestrator_health_is_ready 1 if the node is ready, 0 otherwise.
# TYPE orchestrator_health_is_ready gauge
orchestrator_health_is_ready 1
# HELP orchestrator_instances_total Total number of known instances.
# TYPE orchestrator_instances_total gauge
orchestrator_instances_total 0
# HELP orchestrator_raft_is_healthy 1 if the node is a healthy raft node, 0 otherwise.
# TYPE orchestrator_raft_is_healthy gauge
orchestrator_raft_is_healthy 1
# HELP orchestrator_raft_is_leader 1 if the node is the raft leader, 0 otherwise.
# TYPE orchestrator_raft_is_leader gauge
orchestrator_raft_is_leader 0
# HELP orchestrator_raft_is_part_of_quorum 1 if the node is part of raft quorum, 0 otherwise.
# TYPE orchestrator_raft_is_part_of_quorum gauge
orchestrator_raft_is_part_of_quorum 1
# HELP orchestrator_raft_peers_total Number of known raft peers.
# TYPE orchestrator_raft_peers_total gauge
orchestrator_raft_peers_total 3
# HELP orchestrator_recovery_duration_seconds Duration of recovery operations in seconds.
# TYPE orchestrator_recovery_duration_seconds histogram
orchestrator_recovery_duration_seconds_bucket{le="0.5"} 0
orchestrator_recovery_duration_seconds_bucket{le="1"} 0
orchestrator_recovery_duration_seconds_bucket{le="2"} 0
orchestrator_recovery_duration_seconds_bucket{le="4"} 0
orchestrator_recovery_duration_seconds_bucket{le="8"} 0
orchestrator_recovery_duration_seconds_bucket{le="16"} 0
orchestrator_recovery_duration_seconds_bucket{le="32"} 0
orchestrator_recovery_duration_seconds_bucket{le="64"} 0
orchestrator_recovery_duration_seconds_bucket{le="128"} 0
orchestrator_recovery_duration_seconds_bucket{le="256"} 0
orchestrator_recovery_duration_seconds_bucket{le="512"} 0
orchestrator_recovery_duration_seconds_bucket{le="1024"} 0
orchestrator_recovery_duration_seconds_bucket{le="+Inf"} 0
orchestrator_recovery_duration_seconds_sum 0
orchestrator_recovery_duration_seconds_count 0
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0.09
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 16384
# HELP process_network_receive_bytes_total Number of bytes received by the process over the network.
# TYPE process_network_receive_bytes_total counter
process_network_receive_bytes_total 6.15569222e+08
# HELP process_network_transmit_bytes_total Number of bytes sent by the process over the network.
# TYPE process_network_transmit_bytes_total counter
process_network_transmit_bytes_total 1.182515676e+09
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 21
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 3.2784384e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.77987919043e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 1.84121344e+09
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes 1.8446744073709552e+19
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 0
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
```

### Checklist

Please review the [contribution guidelines](CONTRIBUTING.md) before submitting.

- [x] Code formatted with `gofmt` (please avoid `goimports`)
- [x] Tests added/updated
- [x] CI passes (unit, integration, system tests)
- [x] DCO sign-off included (`git commit -s`)
- [ ] Related issue linked above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded monitoring with new health and cluster-state metrics, including readiness/live, leader/quorum status and peer counts.
  * Added discovery and dead-instance queue length tracking, plus counters for discoveries and discovery errors.
  * New metrics for active recoveries, downtimed instances, and topology-issue counts by type.
  * Recovery operations now record duration and count outcomes (success/failed) for better observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->