### PR TITLE
fix: make orchestrator -version never print empty output (#109)

### DIFF
--- a/go/cmd/orchestrator/main.go
+++ b/go/cmd/orchestrator/main.go
@@ -30,7 +30,28 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
+// AppVersion and GitCommit are normally injected via -ldflags by build.sh / script/build.
+// When building with plain `go build` they are empty; defaultAppVersion (kept in sync with
+// RELEASE_VERSION) is used so `orchestrator -version` is never blank (#109).
 var AppVersion, GitCommit string
+
+// defaultAppVersion must match the contents of the repo-root RELEASE_VERSION file.
+const defaultAppVersion = "4.30.0"
+
+func resolvedAppVersion() string {
+	if AppVersion != "" {
+		return AppVersion
+	}
+	return defaultAppVersion
+}
+
+func versionOutput() string {
+	if AppVersion != "" {
+		return AppVersion
+	}
+	// Plain `go build` without -ldflags: still report the tree version, marked devel.
+	return defaultAppVersion + " (devel)"
+}
 
 // main is the application's entry point. It will either spawn a CLI or HTTP interfaces.
 func main() {
@@ -95,15 +116,19 @@ func main() {
 		log.SetPrintStackTrace(*stack)
 	}
 	if *config.RuntimeCLIFlags.Version {
-		fmt.Println(AppVersion)
-		fmt.Println(GitCommit)
+		fmt.Println(versionOutput())
+		if GitCommit != "" {
+			fmt.Println(GitCommit)
+		}
 		return
 	}
 
-	startText := "starting orchestrator"
-	if AppVersion != "" {
-		startText += ", version: " + AppVersion
+	// Ensure runtime always has a non-empty version (API/status, backend deploy checks).
+	if AppVersion == "" {
+		AppVersion = resolvedAppVersion()
 	}
+
+	startText := "starting orchestrator, version: " + AppVersion
 	if GitCommit != "" {
 		startText += ", git commit: " + GitCommit
 	}

--- a/go/cmd/orchestrator/version_test.go
+++ b/go/cmd/orchestrator/version_test.go
@@ -1,0 +1,67 @@
+/*
+   Copyright 2014 Outbrain Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefaultAppVersionMatchesReleaseFile(t *testing.T) {
+	// Walk up from this test file's package dir to the repo root.
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var release string
+	for {
+		b, err := os.ReadFile(filepath.Join(dir, "RELEASE_VERSION"))
+		if err == nil {
+			release = strings.TrimSpace(string(b))
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("RELEASE_VERSION not found")
+		}
+		dir = parent
+	}
+	if release != defaultAppVersion {
+		t.Fatalf("defaultAppVersion %q must match RELEASE_VERSION %q", defaultAppVersion, release)
+	}
+}
+
+func TestVersionOutputNeverEmpty(t *testing.T) {
+	saved := AppVersion
+	defer func() { AppVersion = saved }()
+
+	AppVersion = ""
+	out := versionOutput()
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("versionOutput empty when AppVersion unset")
+	}
+	if !strings.Contains(out, defaultAppVersion) {
+		t.Fatalf("versionOutput %q missing defaultAppVersion", out)
+	}
+
+	AppVersion = "9.9.9"
+	if versionOutput() != "9.9.9" {
+		t.Fatalf("versionOutput should prefer ldflags AppVersion, got %q", versionOutput())
+	}
+}

--- a/script/build
+++ b/script/build
@@ -12,9 +12,13 @@ cd "$(dirname "$0")/.."
 mkdir -p bin
 bindir="$PWD"/bin
 
-version=$(git rev-parse HEAD)
-describe=$(git describe --tags --always --dirty)
+commit=$(git rev-parse HEAD)
+if [ -f RELEASE_VERSION ]; then
+  version=$(tr -d '[:space:]' < RELEASE_VERSION)
+else
+  version=$(git describe --tags --always --dirty)
+fi
 
-go build -o "$bindir/orchestrator" -ldflags "-X main.AppVersion=${version} -X main.BuildDescribe=${describe}" ./go/cmd/orchestrator/main.go
+go build -o "$bindir/orchestrator" -ldflags "-X main.AppVersion=${version} -X main.GitCommit=${commit}" ./go/cmd/orchestrator/main.go
 
 rsync -qa ./resources $bindir/


### PR DESCRIPTION
## Summary

Fixes #109 — `orchestrator -version` printed nothing after a plain `go build`.

- `AppVersion` / `GitCommit` are only set via `-ldflags` in release builds
- Default to `RELEASE_VERSION` (`4.30.0 (devel)` when ldflags unset)
- Do not print a blank GitCommit line
- Fix `script/build` to set `main.AppVersion` + `main.GitCommit` (was using unused `BuildDescribe`)
- Tests: default matches `RELEASE_VERSION`; version output never empty

## Test plan

- [x] `go test ./go/cmd/orchestrator/`
- [x] `go build -o bin/orchestrator go/cmd/orchestrator/main.go && ./bin/orchestrator -version` → `4.30.0 (devel)`
- [x] ldflags build prints injected version + commit
- [x] `script/build` → version + commit hash