### PR TITLE
ci: add MySQL 9.7 LTS and slim the functional matrix

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mysql_version: ['5.7', '8.0', '8.4', '9.0', '9.2', '9.5', '9.6']
+        mysql_version: ['5.7', '8.0', '8.4', '9.6', '9.7']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Add **MySQL 9.7** to the functional test matrix (9.x LTS; `mysql:9.7` / `lts` on Docker Hub)
- Keep **9.6** as the prior innovation line for a transition window
- Drop intermediate **9.0 / 9.2 / 9.5** to reduce CI cost/time
- Unchanged: **5.7**, **8.0**, **8.4** LTS

### Matrix

| Before | After |
|--------|--------|
| 5.7, 8.0, 8.4, 9.0, 9.2, 9.5, 9.6 | 5.7, 8.0, 8.4, **9.6**, **9.7** |

No product code changes — coverage only. Depends on #108 harness fixes already on master.

## Test plan

- [ ] CI `functional-mysql (9.7)` passes
- [ ] CI `functional-mysql (9.6)` still passes
- [ ] Other matrix cells unchanged/green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated functional testing coverage to run against MySQL versions 5.7, 8.0, 8.4, 9.6, and 9.7.
  * Removed testing coverage for MySQL versions 9.0, 9.2, and 9.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->