### PR TITLE
fix: respect CoMasterRecoveryMustPromoteOtherCoMaster=false when co-m…

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -326,7 +326,7 @@ All process hook fields accept a list of shell commands. Placeholders available:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `CoMasterRecoveryMustPromoteOtherCoMaster` | bool | `true` | When true, only the other co-master can be promoted. When false, any instance is eligible. |
+| `CoMasterRecoveryMustPromoteOtherCoMaster` | bool | `true` | When true, only the other co-master can be promoted. When false, any instance is eligible; this holds even if the surviving co-master is writable, so the operator accepts responsibility for a possible split-brain with a still-writable co-master. |
 | `DetachLostSlavesAfterMasterFailover` | bool | `true` | Synonym for `DetachLostReplicasAfterMasterFailover` |
 | `DetachLostReplicasAfterMasterFailover` | bool | `false` | Forcibly detach replicas that were more up-to-date than the promoted replica |
 | `ApplyMySQLPromotionAfterMasterFailover` | bool | `true` | Should orchestrator apply MySQL master promotion: `set read_only=0`, detach replication, etc. |

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1439,8 +1439,14 @@ func RecoverDeadCoMaster(topologyRecovery *TopologyRecovery, skipProcesses bool)
 
 	mustPromoteOtherCoMaster := config.Config.CoMasterRecoveryMustPromoteOtherCoMaster
 	if !otherCoMaster.ReadOnly {
-		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: other co-master %+v is writeable hence has to be promoted", otherCoMaster.Key))
-		mustPromoteOtherCoMaster = true
+		if mustPromoteOtherCoMaster {
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: other co-master %+v is writeable hence has to be promoted", otherCoMaster.Key))
+		} else {
+			// CoMasterRecoveryMustPromoteOtherCoMaster=false: the admin has explicitly opted out of
+			// forcing co-master promotion. Respect the config rather than overriding it based on
+			// the co-master's read_only state.
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: other co-master %+v is writeable; CoMasterRecoveryMustPromoteOtherCoMaster=false overrides writeable check, will not force promotion", otherCoMaster.Key))
+		}
 	}
 	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: mustPromoteOtherCoMaster? %+v", mustPromoteOtherCoMaster))
 

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1463,7 +1463,7 @@ func RecoverDeadCoMaster(topologyRecovery *TopologyRecovery, skipProcesses bool)
 	}
 	if promotedReplica != nil {
 		if mustPromoteOtherCoMaster && !promotedReplica.Key.Equals(otherCoMasterKey) {
-			_ = topologyRecovery.AddError(log.Errorf("RecoverDeadCoMaster: could not manage to promote other-co-master %+v; was only able to promote %+v; mustPromoteOtherCoMaster is true (either CoMasterRecoveryMustPromoteOtherCoMaster is true, or co-master is writeable), therefore failing", *otherCoMasterKey, promotedReplica.Key))
+			_ = topologyRecovery.AddError(log.Errorf("RecoverDeadCoMaster: could not manage to promote other-co-master %+v; was only able to promote %+v; CoMasterRecoveryMustPromoteOtherCoMaster is true, therefore failing", *otherCoMasterKey, promotedReplica.Key))
 			promotedReplica = nil
 		}
 	}

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1440,12 +1440,12 @@ func RecoverDeadCoMaster(topologyRecovery *TopologyRecovery, skipProcesses bool)
 	mustPromoteOtherCoMaster := config.Config.CoMasterRecoveryMustPromoteOtherCoMaster
 	if !otherCoMaster.ReadOnly {
 		if mustPromoteOtherCoMaster {
-			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: other co-master %+v is writeable hence has to be promoted", otherCoMaster.Key))
+			_ = AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: other co-master %+v is writeable hence has to be promoted", otherCoMaster.Key))
 		} else {
 			// CoMasterRecoveryMustPromoteOtherCoMaster=false: the admin has explicitly opted out of
 			// forcing co-master promotion. Respect the config rather than overriding it based on
 			// the co-master's read_only state.
-			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: other co-master %+v is writeable; CoMasterRecoveryMustPromoteOtherCoMaster=false overrides writeable check, will not force promotion", otherCoMaster.Key))
+			_ = AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: other co-master %+v is writeable; CoMasterRecoveryMustPromoteOtherCoMaster=false overrides writeable check, will not force promotion", otherCoMaster.Key))
 		}
 	}
 	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: mustPromoteOtherCoMaster? %+v", mustPromoteOtherCoMaster))


### PR DESCRIPTION
…aster is writable

When CoMasterRecoveryMustPromoteOtherCoMaster is set to false, the intent is to allow promoting a local replica instead of the co-master. However, the existing code unconditionally overrides mustPromoteOtherCoMaster to true whenever the co-master is writable, making the config setting completely ineffective in active-active M-M setups where both masters must remain writable.

This creates an unresolvable deadlock when combined with PreventCrossDataCenterMasterFailover=true: the ReadOnly override forces co-master promotion, but the cross-DC prevention blocks it, so recovery always fails.

Fix: only set mustPromoteOtherCoMaster=true from the ReadOnly check when the config does not already say false. When CoMasterRecoveryMustPromoteOtherCoMaster=true (the default), behavior is identical to before — no regression.

## Pull Request

Related issue: https://github.com/proxysql/orchestrator/issues/

### Description

This PR [briefly explain what it does]

### Checklist

Please review the [contribution guidelines](CONTRIBUTING.md) before submitting.

- [ ] Code formatted with `gofmt` (please avoid `goimports`)
- [ ] Tests added/updated
- [ ] CI passes (unit, integration, system tests)
- [ ] DCO sign-off included (`git commit -s`)
- [ ] Related issue linked above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected co-master recovery to honor the configured promotion setting, including when the surviving co-master remains writable.
  * Prevented automatic promotion when mandatory promotion is disabled.
  * Updated recovery failure messaging to accurately identify configuration-driven promotion requirements.

* **Documentation**
  * Clarified the configuration behavior and noted the potential split-brain risk when promoting another instance while the surviving co-master remains writable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->