### PR TITLE
Fix read_only scan error on MariaDB via CASE-WHEN string check

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -191,7 +191,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mariadb_version: ['10.6', '10.11']
+        mariadb_version: ['10.6', '10.11', '12.3']
 
     steps:
     - uses: actions/checkout@v4
@@ -273,6 +273,12 @@ jobs:
         MYSQL_IMAGE: mariadb:${{ matrix.mariadb_version }}
         COMPOSE: docker compose -f tests/functional/docker-compose.yml -f tests/functional/docker-compose.mariadb.yml
       run: bash tests/functional/test-smoke.sh
+
+    - name: Run read_only discovery tests
+      env:
+        MYSQL_IMAGE: mariadb:${{ matrix.mariadb_version }}
+        COMPOSE: docker compose -f tests/functional/docker-compose.yml -f tests/functional/docker-compose.mariadb.yml
+      run: bash tests/functional/test-mariadb-read-only.sh
 
     - name: Run relay drain / SQL-stopped failover tests
       env:

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -673,7 +673,7 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 
 		// Synchronously query for some params needed in following go routines
 		var mysqlHostname, mysqlReportHost string
-		err = db.QueryRow("select @@global.hostname, ifnull(@@global.report_host, ''), @@global.server_id, @@global.version_comment, CASE WHEN CAST(@@global.read_only AS CHAR) IN ('1','ON','on') THEN 1 ELSE 0 END, @@global.binlog_format, @@global.log_bin, @@global."+instance.QSP.log_slave_updates()).Scan(
+		err = db.QueryRow("select @@global.hostname, ifnull(@@global.report_host, ''), @@global.server_id, @@global.version_comment, CASE WHEN UPPER(CAST(@@global.read_only AS CHAR)) IN ('0','OFF') THEN 0 ELSE 1 END, @@global.binlog_format, @@global.log_bin, @@global."+instance.QSP.log_slave_updates()).Scan(
 			&mysqlHostname, &mysqlReportHost, &instance.ServerID, &instance.VersionComment, &instance.ReadOnly, &instance.Binlog_format, &instance.LogBinEnabled, &instance.LogReplicationUpdatesEnabled)
 		if err != nil {
 			goto Cleanup

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -673,7 +673,7 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 
 		// Synchronously query for some params needed in following go routines
 		var mysqlHostname, mysqlReportHost string
-		err = db.QueryRow("select @@global.hostname, ifnull(@@global.report_host, ''), @@global.server_id, @@global.version_comment, @@global.read_only, @@global.binlog_format, @@global.log_bin, @@global."+instance.QSP.log_slave_updates()).Scan(
+		err = db.QueryRow("select @@global.hostname, ifnull(@@global.report_host, ''), @@global.server_id, @@global.version_comment, CASE WHEN CAST(@@global.read_only AS CHAR) IN ('1','ON','on') THEN 1 ELSE 0 END, @@global.binlog_format, @@global.log_bin, @@global."+instance.QSP.log_slave_updates()).Scan(
 			&mysqlHostname, &mysqlReportHost, &instance.ServerID, &instance.VersionComment, &instance.ReadOnly, &instance.Binlog_format, &instance.LogBinEnabled, &instance.LogReplicationUpdatesEnabled)
 		if err != nil {
 			goto Cleanup

--- a/tests/functional/docker-compose.mariadb.yml
+++ b/tests/functional/docker-compose.mariadb.yml
@@ -1,17 +1,31 @@
 # Override for MariaDB functional tests (use with docker-compose.yml)
 # MYSQL_IMAGE=mariadb:10.11 docker compose -f docker-compose.yml -f docker-compose.mariadb.yml up -d
+x-mariadb-client-compat: &mariadb-client-compat
+  command: mariadbd
+  entrypoint:
+    - /bin/sh
+    - -c
+    - |
+      ln -sf /usr/bin/mariadb /usr/local/bin/mysql
+      ln -sf /usr/bin/mariadb-admin /usr/local/bin/mysqladmin
+      exec docker-entrypoint.sh "$@"
+    - --
+
 services:
   mysql1:
+    <<: *mariadb-client-compat
     image: ${MYSQL_IMAGE:-mariadb:10.11}
     volumes:
       - ./mysql/mariadb-master.cnf:/etc/mysql/conf.d/repl.cnf
       - ./mysql/init-master.sql:/docker-entrypoint-initdb.d/init.sql
   mysql2:
+    <<: *mariadb-client-compat
     image: ${MYSQL_IMAGE:-mariadb:10.11}
     volumes:
       - ./mysql/mariadb-replica.cnf:/etc/mysql/conf.d/repl.cnf
       - ./mysql/init-replica.sql:/docker-entrypoint-initdb.d/init.sql
   mysql3:
+    <<: *mariadb-client-compat
     image: ${MYSQL_IMAGE:-mariadb:10.11}
     volumes:
       - ./mysql/mariadb-replica2.cnf:/etc/mysql/conf.d/repl.cnf

--- a/tests/functional/test-mariadb-read-only.sh
+++ b/tests/functional/test-mariadb-read-only.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Verify MariaDB read_only enum values are normalized correctly by discovery.
+set -uo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+source tests/functional/lib.sh
+
+echo "=== MARIADB READ_ONLY DISCOVERY TESTS ==="
+
+COMPOSE="${COMPOSE:-docker compose -f tests/functional/docker-compose.yml -f tests/functional/docker-compose.mariadb.yml}"
+TEST_INSTANCE="mysql2"
+
+restore_read_only() {
+    $COMPOSE exec -T "$TEST_INSTANCE" mysql -uroot -ptestpass \
+        -e "SET GLOBAL read_only=ON" >/dev/null 2>&1 || true
+    curl -s --max-time 10 "$ORC_URL/api/discover/$TEST_INSTANCE/3306" >/dev/null 2>&1 || true
+}
+trap restore_read_only EXIT
+
+wait_for_orchestrator || { echo "FATAL: Orchestrator not reachable"; exit 1; }
+discover_topology "mysql1" || { echo "FATAL: Topology not discovered"; exit 1; }
+
+wait_for_api_read_only() {
+    local EXPECTED="$1"
+    local ACTUAL=""
+    for _ in $(seq 1 20); do
+        curl -s --max-time 10 "$ORC_URL/api/discover/$TEST_INSTANCE/3306" >/dev/null 2>&1
+        ACTUAL=$(curl -s --max-time 10 "$ORC_URL/api/instance/$TEST_INSTANCE/3306" 2>/dev/null | python3 -c \
+            "import json,sys; print(str(json.load(sys.stdin).get('ReadOnly')).lower())" 2>/dev/null || echo "")
+        if [ "$ACTUAL" = "$EXPECTED" ]; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "last API ReadOnly value: ${ACTUAL:-unavailable}"
+    return 1
+}
+
+check_mode() {
+    local MODE="$1"
+    local EXPECTED="$2"
+    if ! $COMPOSE exec -T "$TEST_INSTANCE" mysql -uroot -ptestpass \
+        -e "SET GLOBAL read_only=$MODE" >/dev/null 2>&1; then
+        fail "MariaDB rejected read_only=$MODE"
+        return
+    fi
+    if wait_for_api_read_only "$EXPECTED"; then
+        pass "read_only=$MODE is reported as ReadOnly=$EXPECTED"
+    else
+        fail "read_only=$MODE was not reported as ReadOnly=$EXPECTED"
+    fi
+}
+
+check_mode OFF false
+check_mode ON true
+
+MARIADB_MAJOR="$(mysql_version)"
+MARIADB_MAJOR="${MARIADB_MAJOR%%.*}"
+if [ "$MARIADB_MAJOR" -ge 12 ]; then
+    check_mode NO_LOCK true
+    check_mode NO_LOCK_NO_ADMIN true
+else
+    skip "NO_LOCK modes require MariaDB 12 or newer"
+fi
+
+summary


### PR DESCRIPTION
Related issue: https://github.com/proxysql/orchestrator/issues/120

### Description

MariaDB (observed on 12.3.2) returns `@@global.read_only` as a string (`'OFF'`/`'ON'`) rather than an integer when queried via certain client protocols, causing a Go `sql/driver` scan error:

```
sql: Scan error on column index 4, name "@@global.read_only":
sql/driver: couldn't convert "OFF" into type bool
```

This breaks discovery entirely on affected MariaDB versions.

An earlier attempt cast the value to `UNSIGNED` (`CAST(@@global.read_only AS UNSIGNED)`) to force MariaDB to return a plain integer. Lab testing across MariaDB 10.11/11.4/11.8/12.3 and MySQL 8.4/9.7 showed this is unsafe: on some MariaDB versions/protocols `CAST(... AS UNSIGNED)` on the string `'ON'` evaluates to `0` instead of `1`, silently reporting a read-only replica as writable.

Replaced with an explicit string comparison that only treats `'1'` or `'ON'` (case-insensitive) as read-only=true, defaulting safely to not-read-only=false otherwise:

```sql
CASE WHEN CAST(@@global.read_only AS CHAR) IN ('1','ON','on')
     THEN 1 ELSE 0 END
```

Verified via full failover test cycles (discovery, promotion, ProxySQL hostgroup swap, rejoin) against MariaDB 10.11.18, 11.4.12, 11.8.8, 12.3.2 and MySQL 8.4.11, 9.7.2 — zero regressions vs the official v4.31.1 release on the 5 versions unaffected by this bug, and fixes discovery entirely on MariaDB 12.3.2.

### Checklist

Please review the [contribution guidelines](CONTRIBUTING.md) before submitting.

- [x] Code formatted with `gofmt` (please avoid `goimports`)
- [ ] Tests added/updated
- [ ] CI passes (unit, integration, system tests)
- [x] DCO sign-off included (`git commit -s`)
- [x] Related issue linked above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved topology discovery so read-only database instances are consistently identified across supported MariaDB value formats.
  * Prevented valid read-only settings from being incorrectly treated as writable.
  * Ensured read-only status is accurately represented in the instance API, including MariaDB configurations that use textual or numeric modes.

* **Compatibility**
  * Expanded validation across MariaDB 10.6, 10.11, and 12.3 environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->